### PR TITLE
Fix bugs in hotfix/can-mp-in-windows

### DIFF
--- a/modi/_can_task.py
+++ b/modi/_can_task.py
@@ -15,11 +15,8 @@ class CanTask(CommunicatorTask):
     def __init__(self, can_recv_q, can_send_q):
         self._can_recv_q = can_recv_q
         self._can_send_q = can_send_q
-
-        self._open_conn()
-        self.__can0 = can.interface.Bus(
-            channel="can0", bustype="socketcan_ctypes"
-        )
+        
+        self.__can0 = None
 
     def __del__(self):
         self._close_conn()
@@ -40,14 +37,21 @@ class CanTask(CommunicatorTask):
     #
     # Can Methods
     #
-    def _open_conn(self):
+    def open_conn(self):
         os.system("sudo ip link set can0 type can bitrate 1000000")
         os.system("sudo ifconfig can0 up")
+        
+        self.__can0 = can.interface.Bus(
+            channel="can0", bustype="socketcan_ctypes"
+        )
 
     def _close_conn(self):
         os.system("sudo ifconfig can0 down")
 
     def _read_data(self, timeout=None):
+        if self.__can0 is None:
+            raise ValueError("Can is not initialized")
+            
         can_msg = self.__can0.recv(timeout=timeout)
         if can_msg is None:
             raise ValueError("Can message not received!")

--- a/modi/_communicator.py
+++ b/modi/_communicator.py
@@ -11,13 +11,15 @@ class Communicator(mp.Process):
 
     def __init__(self, recv_q, send_q):
         super().__init__()
-        self.__task = CanTask(recv_q, send_q) if (
-            CommunicatorTask.is_on_pi() and
-            not CommunicatorTask.is_network_module_connected()) \
-            else SerTask(recv_q, send_q)
+        self.__task = CanTask(read_q, write_q) if self.__is_modi_pi() else SerTask(read_q, write_q)
         self.__delay = 0.001
 
+    def __is_modi_pi(self):
+        return CommunicatorTask.is_on_pi() and not CommunicatorTask.is_network_module_connected()
+
     def run(self):
+        self.__task.open_conn()
+
         read_thread = th.Thread(
             target=self.__task.run_read_data, args=(self.__delay,)
         )

--- a/modi/_communicator.py
+++ b/modi/_communicator.py
@@ -11,7 +11,7 @@ class Communicator(mp.Process):
 
     def __init__(self, recv_q, send_q):
         super().__init__()
-        self.__task = CanTask(read_q, write_q) if self.__is_modi_pi() else SerTask(read_q, write_q)
+        self.__task = CanTask(recv_q, send_q) if self.__is_modi_pi() else SerTask(recv_q, send_q)
         self.__delay = 0.001
 
     def __is_modi_pi(self):

--- a/modi/_communicator_task.py
+++ b/modi/_communicator_task.py
@@ -37,10 +37,6 @@ class CommunicatorTask(ABC):
     # Abstract Methods
     #
     @abstractmethod
-    def _open_conn(self):
-        pass
-
-    @abstractmethod
     def _close_conn(self):
         pass
 
@@ -50,6 +46,10 @@ class CommunicatorTask(ABC):
 
     @abstractmethod
     def _write_data(self):
+        pass
+
+    @abstractmethod
+    def open_conn(self):
         pass
 
     @abstractmethod

--- a/modi/_ser_task.py
+++ b/modi/_ser_task.py
@@ -14,7 +14,7 @@ class SerTask(CommunicatorTask):
         self._ser_recv_q = ser_recv_q
         self._ser_send_q = ser_send_q
 
-        self.__ser = self._open_conn()
+        self.__ser = None
         self.__json_buffer = ""
 
     def __del__(self):
@@ -23,7 +23,7 @@ class SerTask(CommunicatorTask):
     #
     # Inherited Methods
     #
-    def _open_conn(self):
+    def open_conn(self):
         """ Open serial port
         """
 
@@ -33,17 +33,16 @@ class SerTask(CommunicatorTask):
 
         # TODO: Refactor code to support multiple MODI network modules here
         modi_port = modi_ports.pop()
-        ser = serial.Serial()
-        ser.baudrate = 921600
-        ser.port = modi_port.device
+        self.__ser = serial.Serial()
+        self.__ser.baudrate = 921600
+        self.__ser.port = modi_port.device
 
         # Check if the modi port(i.e. MODI network module) is in use
-        if ser.is_open:
+        if self.__ser.is_open:
             raise SerialException(
-                "The MODI port {} is already in use".format(ser.port)
+                "The MODI port {} is already in use".format(self.__ser.port)
             )
-        ser.open()
-        return ser
+        self.__ser.open()
 
     def _close_conn(self):
         """ Close serial port


### PR DESCRIPTION
Bugs include,

1. Multiprocessing pickle in Windows
2. Rearrange abstract open_conn method in Linux