### PR TITLE
Fix unittest compatibility with v0.8.0

### DIFF
--- a/modi/module/output_module/display.py
+++ b/modi/module/output_module/display.py
@@ -53,5 +53,6 @@ class Display(OutputModule):
             bytes(2),
             self.PropertyDataType.RAW
         )
+
         self._msg_send_q.put(message)
         return message

--- a/modi/module/output_module/output_module.py
+++ b/modi/module/output_module/output_module.py
@@ -27,7 +27,6 @@ class OutputModule(Module):
         message["c"] = 0x04
         message["s"] = property_type
         message["d"] = destination_id
-
         # Generate property according to their property type
         property_values_bytes = bytearray(8)
         if (
@@ -77,7 +76,6 @@ class OutputModule(Module):
             property_values_bytes[7] = 0x00
         else:
             raise RuntimeError("Not supported property data type.")
-
         message["b"] = base64.b64encode(
             bytes(property_values_bytes)).decode("utf-8")
         message["l"] = 8

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -10,105 +10,105 @@ class TestDisplay(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures, if any."""
-        self.mock_kwargs = {"id_": -1, "uuid": -1, "can_write_q": None}
+        self.mock_kwargs = {"id_": -1, "uuid": -1, "msg_send_q": None}
         self.display = Display(**self.mock_kwargs)
 
         def eval_set_property(id, property_type, data, property_data_type):
             eval_result = {
-                self.display.PropertyType.TEXT: [property_type],
-                self.display.PropertyType.VARIABLE: property_type,
-                self.display.PropertyType.CLEAR: property_type,
+                self.display.PropertyType.TEXT.value: [property_type],
+                self.display.PropertyType.VARIABLE.value: property_type,
+                self.display.PropertyType.CLEAR.value: property_type,
             }.get(property_type)
             return eval_result
 
         self.display._set_property = mock.Mock(side_effect=eval_set_property)
-        self.display._can_write_q = mock.Mock()
+        self.display._msg_send_q = mock.Mock()
 
     def tearDown(self):
         """Tear down test fixtures, if any."""
         del self.display
 
-    # def test_set_text(self):
-    #    """Test set_text method."""
-    #    mock_text = "abcd"
-    #    self.display.set_text(text=mock_text)
+    def test_set_text(self):
+        """Test set_text method."""
+        mock_text = "abcd"
+        self.display.set_text(text=mock_text)
 
-    #    expected_clear_params = (
-    #        self.mock_kwargs["id_"],
-    #        self.display.PropertyType.CLEAR,
-    #        bytes(2),
-    #        self.display.PropertyDataType.RAW,
-    #    )
+        expected_clear_params = (
+            self.mock_kwargs["id_"],
+            self.display.PropertyType.CLEAR.value,
+            bytes(2),
+            self.display.PropertyDataType.RAW,
+        )
 
-    #    expected_text_params = (
-    #        self.mock_kwargs["id_"],
-    #        self.display.PropertyType.TEXT,
-    #        mock_text,
-    #        self.display.PropertyDataType.STRING,
-    #    )
+        expected_text_params = (
+           self.mock_kwargs["id_"],
+           self.display.PropertyType.TEXT.value,
+           mock_text,
+           self.display.PropertyDataType.STRING,
+        )
 
-    #    self.assertEqual(self.display._set_property.call_count, 2)
+        self.assertEqual(self.display._set_property.call_count, 2)
 
-    #    # TODO: Refactor two functions calls below to use assert_has_calls()
-    #    self.assertEqual(
-    #        mock.call(*expected_clear_params),
-    #        self.display._set_property.call_args_list[0],
-    #    )
-    #    self.assertEqual(
-    #        mock.call(*expected_text_params),
-    #        self.display._set_property.call_args_list[1],
-    #    )
+        # TODO: Refactor two functions calls below to use assert_has_calls()
+        self.assertEqual(
+           mock.call(*expected_clear_params),
+           self.display._set_property.call_args_list[0],
+        )
+        self.assertEqual(
+           mock.call(*expected_text_params),
+           self.display._set_property.call_args_list[1],
+        )
 
-    # def test_set_variable(self):
-    #    """Test set_variable method."""
-    #    mock_variable = "12345"
-    #    mock_position = 5
-    #    self.display.set_variable(mock_variable, mock_position, mock_position)
+    def test_set_variable(self):
+        """Test set_variable method."""
+        mock_variable = "12345"
+        mock_position = 5
+        self.display.set_variable(mock_variable, mock_position, mock_position)
 
-    #    expected_clear_params = (
-    #        self.mock_kwargs["id_"],
-    #        self.display.PropertyType.CLEAR,
-    #        bytes(2),
-    #        self.display.PropertyDataType.RAW,
-    #    )
+        expected_clear_params = (
+            self.mock_kwargs["id_"],
+            self.display.PropertyType.CLEAR.value,
+            bytes(2),
+            self.display.PropertyDataType.RAW,
+        )
 
-    #    expected_variable_params = (
-    #        self.mock_kwargs["id_"],
-    #        self.display.PropertyType.VARIABLE,
-    #        (mock_variable, mock_position, mock_position),
-    #        self.display.PropertyDataType.DISPLAY_VAR,
-    #    )
+        expected_variable_params = (
+            self.mock_kwargs["id_"],
+            self.display.PropertyType.VARIABLE.value,
+            (mock_variable, mock_position, mock_position),
+            self.display.PropertyDataType.DISPLAY_VAR,
+        )
 
-    #    self.assertEqual(self.display._set_property.call_count, 2)
+        self.assertEqual(self.display._set_property.call_count, 2)
 
-    #    # TODO: Refactor two functions calls below to use assert_has_calls()
-    #    self.assertEqual(
-    #        mock.call(*expected_clear_params),
-    #        self.display._set_property.call_args_list[0],
-    #    )
-    #    self.assertEqual(
-    #        mock.call(*expected_variable_params),
-    #        self.display._set_property.call_args_list[1],
-    #    )
+        # TODO: Refactor two functions calls below to use assert_has_calls()
+        self.assertEqual(
+            mock.call(*expected_clear_params),
+            self.display._set_property.call_args_list[0],
+        )
+        self.assertEqual(
+            mock.call(*expected_variable_params),
+            self.display._set_property.call_args_list[1],
+        )
 
-    # def test_clear(self):
-    #    """Test clear method."""
-    #    self.display.clear()
+    def test_clear(self):
+        """Test clear method."""
+        self.display.clear()
 
-    #    # Check if set_property is called once with the specified arguments
-    #    expected_clear_params = (
-    #        self.mock_kwargs["id_"],
-    #        self.display.PropertyType.CLEAR,
-    #        bytes(2),
-    #        self.display.PropertyDataType.RAW,
-    #    )
-    #    self.display._set_property.assert_called_once_with(
-    #        *expected_clear_params)
+        # Check if set_property is called once with the specified arguments
+        expected_clear_params = (
+            self.mock_kwargs["id_"],
+            self.display.PropertyType.CLEAR.value,
+            bytes(2),
+            self.display.PropertyDataType.RAW,
+        )
+        self.display._set_property.assert_called_once_with(
+            *expected_clear_params)
 
-    #    # Check if correct message has been passed to serial_write_q
-    #    self.display._serial_write_q.put.assert_called_once_with(
-    #        self.display.PropertyType.CLEAR
-    #    )
+        # Check if correct message has been passed to serial_write_q
+        self.display._msg_send_q.put.assert_called_once_with(
+            self.display.PropertyType.CLEAR.value
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_led.py
+++ b/tests/test_led.py
@@ -10,7 +10,7 @@ class TestLed(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures, if any."""
-        self.mock_kwargs = {"id_": -1, "uuid": -1, "can_write_q": None}
+        self.mock_kwargs = {"id_": -1, "uuid": -1, "msg_send_q": None}
         self.led = Led(**self.mock_kwargs)
 
         def eval_set_property(id, command_type, data):
@@ -18,7 +18,7 @@ class TestLed(unittest.TestCase):
 
         self.led._set_property = mock.Mock(side_effect=eval_set_property)
         self.led._get_property = mock.Mock()
-        self.led._can_write_q = mock.Mock()
+        self.led._msg_send_q = mock.Mock()
 
     def tearDown(self):
         """Tear down test fixtures, if any."""
@@ -38,7 +38,7 @@ class TestLed(unittest.TestCase):
             expected_color,
         )
         self.led._set_property.assert_called_once_with(*expected_rgb_params)
-        self.led._can_write_q.put.assert_called_once_with(
+        self.led._msg_send_q.put.assert_called_once_with(
             self.led.CommandType.SET_RGB.value
         )
 

--- a/tests/test_modi.py
+++ b/tests/test_modi.py
@@ -27,13 +27,8 @@ class TestModi(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures, if any."""
-        self.modi = MODI(test=True)
-
-        self.modi._ser_proc = mock.Mock()
-        self.modi._exe_thrd = mock.Mock()
-
         mock_input_values = (-1, -1, None)
-        self.modi._modules = [
+        mock_modules = [
             SetupModule(*mock_input_values),
             InputModule(*mock_input_values),
             OutputModule(*mock_input_values),
@@ -52,6 +47,12 @@ class TestModi(unittest.TestCase):
             Speaker(*mock_input_values),
         ]
 
+        self.modi = MODI(nb_modules=len(mock_modules), test=True)
+
+        self.modi._ser_proc = mock.Mock()
+        self.modi._exe_thrd = mock.Mock()
+        self.modi._modules = mock_modules
+
     def tearDown(self):
         """Tear down test fixtures, if any."""
         del self.modi
@@ -60,13 +61,6 @@ class TestModi(unittest.TestCase):
         """Test correct initialization of modi instance."""
         # self.assertListEqual(self.modi._modules, list())
         self.assertDictEqual(self.modi._module_ids, dict())
-
-    def test_exit(self):
-        """Test exit method."""
-        self.modi.exit()
-
-        self.modi._ser_proc.stop.assert_called_once_with()
-        self.modi._exe_thrd.stop.assert_called_once_with()
 
     def test_get_modules(self):
         """Test modules getter method."""

--- a/tests/test_motor.py
+++ b/tests/test_motor.py
@@ -10,7 +10,7 @@ class TestMotor(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures, if any."""
-        self.mock_kwargs = {"id_": -1, "uuid": -1, "can_write_q": None}
+        self.mock_kwargs = {"id_": -1, "uuid": -1, "msg_send_q": None}
         self.motor = Motor(**self.mock_kwargs)
 
         def eval_set_property(id, command_type, data):
@@ -18,7 +18,7 @@ class TestMotor(unittest.TestCase):
 
         self.motor._set_property = mock.Mock(side_effect=eval_set_property)
         self.motor._get_property = mock.Mock()
-        self.motor._can_write_q = mock.Mock()
+        self.motor._msg_send_q = mock.Mock()
 
     def tearDown(self):
         """Tear down test fixtures, if any."""

--- a/tests/test_speaker.py
+++ b/tests/test_speaker.py
@@ -10,7 +10,7 @@ class TestSpeaker(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures, if any."""
-        self.mock_kwargs = {"id_": -1, "uuid": -1, "can_write_q": None}
+        self.mock_kwargs = {"id_": -1, "uuid": -1, "msg_send_q": None}
         self.speaker = Speaker(**self.mock_kwargs)
 
         def eval_set_property(id, command_type, data, property_data_type):
@@ -18,7 +18,7 @@ class TestSpeaker(unittest.TestCase):
 
         self.speaker._set_property = mock.Mock(side_effect=eval_set_property)
         self.speaker._get_property = mock.Mock()
-        self.speaker._can_write_q = mock.Mock()
+        self.speaker._msg_send_q = mock.Mock()
 
     def tearDown(self):
         """Tear down test fixtures, if any."""
@@ -41,7 +41,7 @@ class TestSpeaker(unittest.TestCase):
         )
         self.speaker._set_property.assert_called_once_with(
             *expected_tune_params)
-        self.speaker._can_write_q.put.assert_called_once_with(
+        self.speaker._msg_send_q.put.assert_called_once_with(
             self.speaker.CommandType.SET_TUNE.value
         )
 


### PR DESCRIPTION
Features include,

1. Fix the mock arguments for the tests to direct values of the property type
2. Fix function names for the test from _can_write_q to _msg_write_q