### PR TITLE
Add type annotations to tasks, procedures, and thread

### DIFF
--- a/modi/_conn_proc.py
+++ b/modi/_conn_proc.py
@@ -18,17 +18,17 @@ class ConnProc(mp.Process):
         self.__task = self.__init_task(conn_mode)(*params)
         self.__delay = 0.05 if isinstance(self.__task, SppTask) else 0.001
 
-    def __init_task(self, conn_mode):
+    def __init_task(self, conn_mode: str) -> ConnTask:
         if conn_mode.startswith("b"):
             return SppTask
         return CanTask if self.__is_modi_pi() else SerTask
 
     @staticmethod
-    def __is_modi_pi():
+    def __is_modi_pi() -> bool:
         return ConnTask.is_on_pi() and \
                not ConnTask.is_network_module_connected()
 
-    def run(self):
+    def run(self) -> None:
         self.__task.open_conn()
 
         read_thread = th.Thread(

--- a/modi/_exe_thrd.py
+++ b/modi/_exe_thrd.py
@@ -19,7 +19,7 @@ class ExeThrd(th.Thread):
             init_event, nb_modules
         )
 
-    def run(self):
+    def run(self) -> None:
         """ Run executor task
         """
 

--- a/modi/task/can_task.py
+++ b/modi/task/can_task.py
@@ -4,6 +4,7 @@ import time
 import json
 import queue
 import base64
+from typing import Dict, Tuple
 
 from modi.task.conn_task import ConnTask
 
@@ -20,12 +21,12 @@ class CanTask(ConnTask):
     def __del__(self):
         self._close_conn()
 
-    def __can_read(self):
+    def __can_read(self) -> None:
         can_msg = self._read_data()
         json_msg = self.__parse_can_msg(can_msg)
         self._can_recv_q.put(json_msg)
 
-    def __can_write(self):
+    def __can_write(self) -> None:
         try:
             message_to_write = self._can_send_q.get_nowait().encode()
         except queue.Empty:
@@ -36,7 +37,7 @@ class CanTask(ConnTask):
     #
     # Can Methods
     #
-    def open_conn(self):
+    def open_conn(self) -> None:
         os.system("sudo ip link set can0 type can bitrate 1000000")
         os.system("sudo ifconfig can0 up")
 
@@ -44,10 +45,10 @@ class CanTask(ConnTask):
             channel="can0", bustype="socketcan_ctypes"
         )
 
-    def _close_conn(self):
+    def _close_conn(self) -> None:
         os.system("sudo ifconfig can0 down")
 
-    def _read_data(self, timeout=None):
+    def _read_data(self, timeout: float = None) -> can.Message:
         if self.__can0 is None:
             raise ValueError("Can is not initialized")
 
@@ -56,7 +57,7 @@ class CanTask(ConnTask):
             raise ValueError("Can message not received!")
         return can_msg
 
-    def _write_data(self, str_msg):
+    def _write_data(self, str_msg: str) -> None:
         """ Given parsed binary string message in json format,
             convert and send the message as CAN format
         """
@@ -68,12 +69,12 @@ class CanTask(ConnTask):
         except can.CanError:
             raise ValueError("Can message not sent!")
 
-    def run_read_data(self, delay):
+    def run_read_data(self, delay: float) -> None:
         while True:
             self.__can_read()
             time.sleep(delay)
 
-    def run_write_data(self, delay):
+    def run_write_data(self, delay: float) -> None:
         while True:
             self.__can_write()
             time.sleep(delay)
@@ -82,7 +83,7 @@ class CanTask(ConnTask):
     # Can helper methods
     #
     @staticmethod
-    def __parse_can_msg(can_msg):
+    def __parse_can_msg(can_msg: can.Message) -> str:
         """ Parse a can message to json format
         """
         can_id = can_msg.arbitration_id
@@ -99,7 +100,7 @@ class CanTask(ConnTask):
         return json.dumps(json_msg, separators=(",", ":"))
 
     @staticmethod
-    def __parse_can_id(can_id):
+    def __parse_can_id(can_id: str) -> Tuple[int, int, int]:
         """ Parse a 29 bits length Can ID into INS, SID and DID
         """
         BIN = 2
@@ -112,7 +113,7 @@ class CanTask(ConnTask):
         return ins, sid, did
 
     @staticmethod
-    def __compose_can_msg(json_msg):
+    def __compose_can_msg(json_msg: Dict[str, str]) -> can.Message:
         ins = format(json_msg["c"], '05b')
         sid = format(json_msg["s"], '012b')
         did = format(json_msg["d"], '012b')

--- a/modi/task/conn_task.py
+++ b/modi/task/conn_task.py
@@ -2,10 +2,11 @@
 import os
 
 import serial.tools.list_ports as stl
+from serial.tools.list_ports_common import ListPortInfo
 
 from abc import ABC
 from abc import abstractmethod
-
+from typing import List
 
 class ConnTask(ABC):
 
@@ -14,7 +15,7 @@ class ConnTask(ABC):
         self._send_q = send_q
 
     @staticmethod
-    def _list_modi_ports():
+    def _list_modi_ports() -> List[ListPortInfo]:
         def __is_modi_port(port):
             return (
                 port.manufacturer == "LUXROBO" or
@@ -26,11 +27,11 @@ class ConnTask(ABC):
         return [port for port in stl.comports() if __is_modi_port(port)]
 
     @staticmethod
-    def is_on_pi():
+    def is_on_pi() -> bool:
         return os.name != "nt" and os.uname()[4][:3] == "arm"
 
     @staticmethod
-    def is_network_module_connected():
+    def is_network_module_connected() -> bool:
         return bool(ConnTask._list_modi_ports())
 
     #
@@ -53,9 +54,9 @@ class ConnTask(ABC):
         pass
 
     @abstractmethod
-    def run_read_data(self, delay):
+    def run_read_data(self, delay: float):
         pass
 
     @abstractmethod
-    def run_write_data(self, delay):
+    def run_write_data(self, delay: float):
         pass

--- a/modi/task/ser_task.py
+++ b/modi/task/ser_task.py
@@ -21,7 +21,7 @@ class SerTask(ConnTask):
     #
     # Inherited Methods
     #
-    def open_conn(self):
+    def open_conn(self) -> None:
         """ Open serial port
         """
 
@@ -42,13 +42,13 @@ class SerTask(ConnTask):
             )
         self.__ser.open()
 
-    def _close_conn(self):
+    def _close_conn(self) -> None:
         """ Close serial port
         """
 
         self.__ser.close()
 
-    def _read_data(self):
+    def _read_data(self) -> None:
         """ Read serial message and put message to serial read queue
         """
 
@@ -62,7 +62,7 @@ class SerTask(ConnTask):
             # Once json buffer is obtained, we parse and send json message
             self.__parse_serial()
 
-    def _write_data(self):
+    def _write_data(self) -> None:
         """ Write serial message in serial write queue
         """
 
@@ -73,12 +73,12 @@ class SerTask(ConnTask):
         else:
             self.__ser.write(message_to_write)
 
-    def run_read_data(self, delay):
+    def run_read_data(self, delay: float) -> None:
         while True:
             self._read_data()
             time.sleep(delay)
 
-    def run_write_data(self, delay):
+    def run_write_data(self, delay: float) -> None:
         while True:
             self._write_data()
             time.sleep(delay)
@@ -86,7 +86,7 @@ class SerTask(ConnTask):
     #
     # Helper method
     #
-    def __parse_serial(self):
+    def __parse_serial(self) -> None:
         # While there is a valid json in the json buffer
         while "{" in self.__json_buffer and "}" in self.__json_buffer:
             split_index = self.__json_buffer.find("}") + 1

--- a/modi/task/spp_task.py
+++ b/modi/task/spp_task.py
@@ -2,6 +2,8 @@ import time
 import queue
 import serial
 import serial.tools.list_ports as stl
+from serial.tools.list_ports_common import ListPortInfo
+from typing import List
 
 from serial import SerialException
 
@@ -20,7 +22,7 @@ class SppTask(ConnTask):
         self.__ser = None
         self.__json_buffer = ""
 
-    def _list_modi_ports(self):
+    def _list_modi_ports(self) -> List[ListPortInfo]:
         modi_ports = list()
         ports = stl.comports()
         for port in ports:
@@ -46,7 +48,7 @@ class SppTask(ConnTask):
     #
     # Inherited Methods
     #
-    def open_conn(self):
+    def open_conn(self) -> None:
         """ Open serial port
         """
 
@@ -66,13 +68,13 @@ class SppTask(ConnTask):
         self.__ser.open()
         time.sleep(1)
 
-    def _close_conn(self):
+    def _close_conn(self) -> None:
         """ Close serial port
         """
 
         self.__ser.close()
 
-    def _read_data(self):
+    def _read_data(self) -> None:
         """ Read serial message and put message to serial read queue
         """
 
@@ -86,7 +88,7 @@ class SppTask(ConnTask):
             # Once json buffer is obtained, we parse and send json message
             self.__parse_serial()
 
-    def _write_data(self):
+    def _write_data(self) -> None:
         """ Write serial message in serial write queue
         """
 
@@ -97,12 +99,12 @@ class SppTask(ConnTask):
         else:
             self.__ser.write(message_to_write)
 
-    def run_read_data(self, delay):
+    def run_read_data(self, delay: float) -> None:
         while True:
             self._read_data()
             time.sleep(delay)
 
-    def run_write_data(self, delay):
+    def run_write_data(self, delay: float) -> None:
         while True:
             self._write_data()
             time.sleep(delay)
@@ -110,7 +112,7 @@ class SppTask(ConnTask):
     #
     # Helper method
     #
-    def __parse_serial(self):
+    def __parse_serial(self) -> None:
         # While there is a valid json in the json buffer
         while "{" in self.__json_buffer and "}" in self.__json_buffer:
             split_index = self.__json_buffer.find("}") + 1


### PR DESCRIPTION
Features include,

1. Add type annotations to methods in conn_task.py, can_task.py, exe_task.py, ser_task.py, spp_task.py
2. Add type annotations to methods in _conn_proc.py and _exe_thrd.py 