### PR TITLE
Implement print_topology_map method with module id

### DIFF
--- a/modi/modi.py
+++ b/modi/modi.py
@@ -1,7 +1,7 @@
 """Main MODI module."""
 
 import time
-from typing import Tuple
+from typing import Dict, List, Tuple
 
 import threading as th
 import multiprocessing as mp
@@ -9,6 +9,8 @@ import multiprocessing as mp
 import networkx as nx
 
 from pprint import pprint
+
+from modi.topology_manager import TopologyManager
 
 from modi._conn_proc import ConnProc
 from modi._exe_thrd import ExeThrd
@@ -71,7 +73,7 @@ class MODI:
         self._exe_thrd.daemon = True
         self._exe_thrd.start()
         time.sleep(1)
-
+        self._topology_manager = TopologyManager(self._topology_data)
         module_init_timeout = 10 if conn_mode.startswith("ser") else 25
         module_init_flag.wait(timeout=module_init_timeout)
         if not module_init_flag.is_set():
@@ -86,216 +88,13 @@ class MODI:
         for module in self.modules:
             pprint('module: {}, module_id: {}'.format(module, module.id))
 
-    def print_topology_map(self):
-        tp_data = self._topology_data
-        num_modules = len(tp_data.keys())
-        map_list = []
-        for i in range(2 * num_modules):
-            row = []
-            for j in range(2 * num_modules):
-                row.append(0)
-            map_list.append(row)
-        init_id = list(tp_data.keys())[0]
-        so_far = []
+    def print_topology_map(self, print_id: bool = False):
+        """Prints out the topology map
 
-        def set_orietation(mod_data, prev_id, up):
-            c = 'l'
-            dirs = ['b', 'r', 't', 'l']
-            for d in dirs:
-                if mod_data[d] == prev_id:
-                    c = d
-            n = dirs.index(c)
-            for j in range(n):
-                up = (up[1], -up[0])
-            return up
-
-        def rotate(d, up):
-            n = {'t': 0, 'r': 1, 'b': 2, 'l': 3}.get(d)
-            for j in range(n):
-                up = (up[1], -up[0])
-            return up
-
-        def update_map(module_id, x, y, prev_id, up):
-            if module_id in so_far:
-                return
-            #print(module_id,x,y,prev_id,up)
-            module_data = tp_data[module_id]
-            map_list[y][x] = module_id
-            so_far.append(module_id)
-
-            up = set_orietation(module_data, prev_id, up)
-            #print("Correct upward is",up)
-            for d in ['t', 'b', 'l', 'r']:
-                if module_data[d] is not None:
-                    toward = rotate(d, up)
-                    update_map(module_data[d], x + toward[0], y + toward[1], module_id, toward)
-
-        update_map(init_id, num_modules, num_modules, -1, (1, 0))
-
-        x, y, w, h = -1, -1, 1, 1
-
-        for i in range(len(map_list)):
-            if sum(map_list[i]) > 0 and y < 0:
-                y = i
-            elif sum(map_list[i]) > 0 and y >= 0:
-                h += 1
-        for i in range(len(map_list[0])):
-            col = list(map(lambda L: L[i], map_list))
-            if sum(col) > 0 and x < 0:
-                x = i
-            elif sum(col) > 0 and x >= 0:
-                w += 1
-        title = "<<MODI Topology Map>>"
-        print(" " * ((10 * w - len(title)) // 2) + title)
-        print("=" * 10 * w)
-        for i in range(y + h - 1, y - 1, -1):
-            line = ""
-            row = map_list[i]
-            for j in range(x, x+ w + 1):
-                m = row[j]
-                if m is 0:
-                    line += " " * 10
-                else:
-                    line += "{0:^10s}".format(self.__get_type_from_uuid(tp_data[m]['uuid']))
-            print(line)
-
-    def print_topology_tree(self) -> None:
-        """Print topology map
-
+        :param print_id: If True, the result includes module id
         :return: None
         """
-        class Tree:
-            def __init__(self, module_id):
-                self.connected_modules = []
-                self.id = module_id
-
-            def make_tree(self, so_far, data):
-                directions = ['t', 'b', 'l', 'r']
-                module_data = data[self.id]
-                for direction in directions:
-                    conn_id = module_data[direction]
-                    if conn_id not in so_far and conn_id is not None:
-                        so_far.append(conn_id)
-                        child = Tree(conn_id)
-                        child.make_tree(so_far, data)
-                        self.connected_modules.append(child)
-
-        def print_tree(tree, depth):
-            name = self.__get_type_from_uuid(tp_data[tree.id]['uuid'])
-            s = name
-            depth += len(name)
-            for i in range(len(tree.connected_modules)):
-                if i is not 0:
-                    s += " " * depth
-                s += " - " + print_tree(tree.connected_modules[i], depth+3)
-            if len(tree.connected_modules) is 0:
-                s += "\n"
-            return s
-
-        tp_data = self._topology_data
-        init_id = list(tp_data.keys())[0]
-        tp_tree = Tree(init_id)
-        tp_tree.make_tree([init_id], tp_data)
-        print("\n<<MODI Topology Map>>")
-        print("Ex) ModuleA -ModuleB "+'\n'+"            -ModuleC")
-        print("means that ModuleB and ModuleC are connected to ModuleA.")
-
-        print("-" * 60)
-        print(print_tree(tp_tree, 0), end='')
-
-    def print_topology_matrix(self) -> None:
-        """Print the topology map
-
-        :return: None
-        """
-        # start_time = time.time()
-        tp_data = self._topology_data
-        graph = nx.Graph()
-
-        # Init graph nodes
-        labels = {}
-        for module_id in tp_data:
-            curr_module_tp_data = tp_data[module_id]
-            module_type = self.__get_type_from_uuid(
-                curr_module_tp_data['uuid']
-            )
-            labels[module_id] = module_type
-            graph.add_node(module_id)
-        # print('graph.nodes():', graph.nodes())
-
-        # Init graph edges
-        for module_id in tp_data:
-            curr_edges = []
-            curr_module_tp_data = tp_data[module_id]
-
-            # Check if module exists at R (Right) T (Top) L (Left) B (Bottom)
-            if curr_module_tp_data['r'] is not None:
-                edge_to_right = (module_id, curr_module_tp_data['r'])
-                curr_edges.append(edge_to_right)
-            if curr_module_tp_data['t'] is not None:
-                edge_to_top = (module_id, curr_module_tp_data['t'])
-                curr_edges.append(edge_to_top)
-            if curr_module_tp_data['l'] is not None:
-                edge_to_left = (module_id, curr_module_tp_data['l'])
-                curr_edges.append(edge_to_left)
-            if curr_module_tp_data['b'] is not None:
-                edge_to_bottom = (module_id, curr_module_tp_data['b'])
-                curr_edges.append(edge_to_bottom)
-
-            graph.add_edges_from(curr_edges)
-
-        graph = nx.relabel_nodes(graph, labels)
-        matrix = nx.adjacency_matrix(graph).todense().tolist()
-        nodes = list(graph)
-        table_length = 13 * (len(nodes) + 1) - 2
-
-        title = "<<Topology Adjacency Matrix>>"
-        result = "\n" + " " * ((table_length - len(title)) // 2) + title + "\n"
-        result += "=" * table_length + "\n" + " " * 10 + "| "
-        for node in nodes:
-            result += "{0:<10} | ".format(node)
-        result += '\n' + '-' * table_length + '\n'
-        for i in range(len(nodes)):
-            result += "{0:<10}| ".format(nodes[i])
-            for elem in matrix[i]:
-                result += "{0:<10} | ".format(elem)
-            result += '\n'
-        print(result)
-        # print('graph.edges():', graph.edges())
-        #labeled_graph = nx.relabel_nodes(graph, labels)
-        # print('total time taken:', time.time() - start_time)
-        #return labeled_graph
-
-    def __get_type_from_uuid(self, uuid: int) -> str:
-        """Returns type based on uuid
-
-        :param uuid: UUID of the required type
-        :type uuid: int
-        :return: Corresponding type
-        :rtype: str
-        """
-        if uuid is None:
-            return 'Network'
-
-        hexadecimal = hex(uuid).lstrip("0x")
-        type_indicator = str(hexadecimal)[:4]
-        module_type = {
-            # Input modules
-            '2000': 'Env',
-            '2010': 'Gyro',
-            '2020': 'Mic',
-            '2030': 'Button',
-            '2040': 'Dial',
-            '2050': 'Ultrasonic',
-            '2060': 'Infrared',
-
-            # Output modules
-            '4000': 'Display',
-            '4010': 'Motor',
-            '4020': 'Led',
-            '4030': 'Speaker',
-        }.get(type_indicator)
-        return module_type
+        self._topology_manager.print_topology_map(print_id)
 
     @property
     def modules(self):

--- a/modi/modi.py
+++ b/modi/modi.py
@@ -6,8 +6,6 @@ from typing import Dict, List, Tuple
 import threading as th
 import multiprocessing as mp
 
-import networkx as nx
-
 from pprint import pprint
 
 from modi.topology_manager import TopologyManager

--- a/modi/topology_manager.py
+++ b/modi/topology_manager.py
@@ -1,0 +1,206 @@
+
+from typing import Dict, List, Tuple
+
+
+class TopologyMap:
+    def __init__(self, tp_data, nb_modules):
+        self._nb_modules = nb_modules
+        self._tp_data = tp_data
+
+        # 2D array that will contain the topology information of the modules.
+        # It stores the module id
+        self._tp_map = [[0 for _ in range(2 * self._nb_modules)]
+                        for _ in range(2 * self._nb_modules)]
+
+    @staticmethod
+    def __get_module_orientation(mod_data: Dict[str, int], prev_id: int,
+                                 toward: Tuple[int, int]) -> Tuple[int, int]:
+        """Finds out the upward direction based on the orientation of the
+        module. When updating the map, it recursively traverses through modules
+        to update the module_matrix. Since module's local top is not the same
+        as the global top, we find out the true "top" direction based on the
+        module's direction.
+
+        :param mod_data: module's topology data
+        :param prev_id: module id from which the module traversed
+        :param toward: direction to which the module traversed
+        :return: upward vector of the module in Tuple[int, int]
+        """
+        dirs = [bottom, right, top, left] = ['b', 'r', 't', 'l']
+
+        # Finds out the direction of the previous module
+        prev_module_dir = 'l'
+        for d in dirs:
+            if mod_data[d] == prev_id:
+                prev_module_dir = d
+
+        # Based on the direction, find out the top vector, by rotating the
+        # toward vector accordingly
+        nb_rotations = dirs.index(prev_module_dir)
+        for _ in range(nb_rotations):
+            toward = (toward[1], -toward[0])
+        return toward
+
+    @staticmethod
+    def __get_rotated_direction(direction: str, up_vector: Tuple[int, int]):
+        """Rotate the top_vector to get the required direction.
+        Ex) direction == 'r' and up_vector == (0, 1) => then returns (1, 0)
+
+        :param direction: char notation of the direction
+        :param up_vector: up_vector direction
+        :return: rotated vector pointing at the desired direction
+        """
+        nb_rotation = {'t': 0, 'r': 1, 'b': 2, 'l': 3}.get(direction)
+        for _ in range(nb_rotation):
+            up_vector = (up_vector[1], -up_vector[0])
+        return up_vector
+
+    def __update_map(self, module_id: int, x: int, y: int, prev_id: int,
+                     toward: Tuple[int, int], visited: List[int]):
+        """Recursively updates the map
+
+        :param module_id: id of the current module
+        :param x: x coordinate on the map
+        :param y: y coordinate on the map
+        :param prev_id: id of the previously traversed module
+        :param toward: direction from which the module traversed
+        :param visited: list of visited modules
+        :return: None
+        """
+        if module_id in visited:
+            return
+        module_data = self._tp_data[module_id]
+        self._tp_map[y][x] = module_id
+        visited.append(module_id)
+        up_vector = self.__get_module_orientation(module_data, prev_id, toward)
+        for d in ['t', 'b', 'l', 'r']:
+            if module_data.get(d) is not None:
+                toward = self.__get_rotated_direction(d, up_vector)
+                self.__update_map(module_data.get(d), x + toward[0],
+                                  y + toward[1], module_id, toward, visited)
+
+    def construct_map(self) -> None:
+        """Construct the topology map
+
+        :return: None
+        """
+        first_id = list(self._tp_data.keys())[0]
+        visited = []
+        self.__update_map(first_id, self._nb_modules, self._nb_modules,
+                          prev_id=-1, toward=(1, 0), visited=visited)
+
+    def print_map(self, print_id: bool = False) -> None:
+        """ Prints out the topology map
+
+        :param print_id: If True, the result includes id in the topology map
+        :type print_id: bool
+        :return: None
+        """
+        # Trims the matrix to get rid of empty spaces, containing zeros only
+        x, y, w, h = -1, -1, 1, 1
+
+        """
+        x, y indicates the coordinate from which the topology map contains
+         non-zero element
+        w, h indicates the width and height of non-zero elements in the map
+        Since most of the elements in the map are zeros, x, y, w, h represents
+        the window in which module ids are the elements of the map.
+        """
+
+        # Iterates through the rows until it finds the first non-zero row.
+        # Saves the index to y, and increases h until it finds next all-zero
+        # row
+        for i in range(len(self._tp_map)):
+            if sum(self._tp_map[i]) > 0 and y < 0:
+                y = i
+            elif sum(self._tp_map[i]) > 0 and y >= 0:
+                h += 1
+
+        # Iterates through the columns until it finds the first non-zero column.
+        # Saves the index to x, and increases w until it finds next all-zero
+        # column.
+        for i in range(len(self._tp_map[0])):
+            col = list(map(lambda m: m[i], self._tp_map))
+            if sum(col) > 0 and x < 0:
+                x = i
+            elif sum(col) > 0 and x >= 0:
+                w += 1
+
+        """
+        Prints out the map by a format
+        padding is the length of the placeholder for the module names.
+        if we want to print id as well, padding should be longer to 17.
+        The method prints out the window determined by x, y, w, h.
+        """
+        padding = 10
+        if print_id: padding = 17
+        title = "<<MODI Topology Map>>"
+        print(" " * ((padding * w - len(title)) // 2) + title)
+        print("=" * padding * w)
+        for i in range(y + h - 1, y - 1, -1):
+            line = ""
+            row = self._tp_map[i]
+            for j in range(x, x + w + 1):
+                curr_elem = row[j]
+                if not curr_elem:
+                    line += " " * padding
+                else:
+                    if print_id:
+                        line += "{0:^17s}".format(
+                            TopologyManager.get_type_from_uuid(
+                                self._tp_data[curr_elem]['uuid']) + ":" +
+                            str(curr_elem))
+                    else:
+                        line += "{0:^10s}".format(
+                            TopologyManager.get_type_from_uuid(
+                                self._tp_data[curr_elem]['uuid']))
+            print(line)
+
+
+class TopologyManager:
+
+    def __init__(self, topology_data):
+        self._tp_data = topology_data
+        self._nb_modules = len(self._tp_data.keys())
+
+    def print_topology_map(self, print_id: bool = False) -> None:
+        """ Print the topology map
+
+        :param print_id: If True, the result includes module ids
+        :return: None
+        """
+        tp_map = TopologyMap(self._tp_data, self._nb_modules)
+        tp_map.construct_map()
+        tp_map.print_map(print_id)
+
+    @staticmethod
+    def get_type_from_uuid(uuid: int) -> str:
+        """Returns type based on uuid
+
+        :param uuid: UUID of the required type
+        :type uuid: int
+        :return: Corresponding type
+        :rtype: str
+        """
+        if uuid is None:
+            return 'Network'
+
+        hexadecimal = hex(uuid).lstrip("0x")
+        type_indicator = str(hexadecimal)[:4]
+        module_type = {
+            # Input modules
+            '2000': 'Env',
+            '2010': 'Gyro',
+            '2020': 'Mic',
+            '2030': 'Button',
+            '2040': 'Dial',
+            '2050': 'Ultrasonic',
+            '2060': 'Infrared',
+
+            # Output modules
+            '4000': 'Display',
+            '4010': 'Motor',
+            '4020': 'Led',
+            '4030': 'Speaker',
+        }.get(type_indicator)
+        return module_type

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 pyserial
 enum34
-networkx
 python-can
-scipy

--- a/tests/test_modi.py
+++ b/tests/test_modi.py
@@ -181,7 +181,10 @@ class TestModi(unittest.TestCase):
     # def test_print_topology_map(self):
     #     """Test print_topology_map method"""
     #     bundle = MODI(7)
+    #     bundle.print_topology_map(True)
+    #     print()
     #     bundle.print_topology_map()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_modi.py
+++ b/tests/test_modi.py
@@ -178,10 +178,10 @@ class TestModi(unittest.TestCase):
         self.assertIsInstance(actual_modules, tuple)
         self.assertTupleEqual(actual_modules, expected_modules)
 
-    def test_print_topology_map(self):
-        """Test print_topology_map method"""
-        bundle = MODI(7)
-        bundle.print_topology_map()
+    # def test_print_topology_map(self):
+    #     """Test print_topology_map method"""
+    #     bundle = MODI(7)
+    #     bundle.print_topology_map()
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_modi.py
+++ b/tests/test_modi.py
@@ -178,10 +178,10 @@ class TestModi(unittest.TestCase):
         self.assertIsInstance(actual_modules, tuple)
         self.assertTupleEqual(actual_modules, expected_modules)
 
-    # def test_print_topology_map(self):
-    #     """Test print_topology_map method"""
-    #     bundle = MODI(3)
-    #     bundle.print_topology_map()
+    def test_print_topology_map(self):
+        """Test print_topology_map method"""
+        bundle = MODI(7)
+        bundle.print_topology_map()
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Features include,

1. Add topology manager class to take care of all topology related operations
2. Add print_topology_map method to print out the topology map to stdout
3. Add feature to print out topology map with module ids included.
4. Remove dependencies on networks and scipy