### PR TITLE
Enable modi object to be initialized without nb_modules

### DIFF
--- a/modi/modi.py
+++ b/modi/modi.py
@@ -17,6 +17,7 @@ from modi.module.module import Module
 from modi.util.topology_manager import TopologyManager
 from modi.util.firmware_updater import FirmwareUpdater
 from modi.util.stranger import check_complete
+from modi.util.misc import module_list
 
 
 class MODI:
@@ -26,7 +27,7 @@ class MODI:
     >>> bundle = modi.MODI()
     """
 
-    def __init__(self, nb_modules: int, conn_mode: str = "serial",
+    def __init__(self, nb_modules: int = 1, conn_mode: str = "serial",
                  module_uuid: str = "", test: bool = False,
                  verbose: bool = False):
 
@@ -96,11 +97,11 @@ class MODI:
 
         self._topology_manager = TopologyManager(self._topology_data)
 
-        module_init_flag.wait()
-        if not module_init_flag.is_set():
-            raise Exception("Modules are not initialized properly!")
-            exit(1)
-        print("MODI modules are initialized!")
+        # module_init_flag.wait()
+        # if not module_init_flag.is_set():
+        #     raise Exception("Modules are not initialized properly!")
+        #     exit(1)
+        # print("MODI modules are initialized!")
         check_complete(self)
 
     def update_module_firmware(self) -> None:
@@ -137,86 +138,74 @@ class MODI:
     def buttons(self) -> Tuple[Module]:
         """Tuple of connected :class:`~modi.module.button.Button` modules.
         """
-
-        return tuple([module for module in self.modules
-                      if module.type == "button"])
+        return module_list(self._modules, 'button')
 
     @property
     def dials(self) -> Tuple[Module]:
         """Tuple of connected :class:`~modi.module.dial.Dial` modules.
         """
 
-        return tuple([module for module in self.modules
-                      if module.type == "dial"])
+        return module_list(self._modules, "dial")
 
     @property
     def displays(self) -> Tuple[Module]:
         """Tuple of connected :class:`~modi.module.display.Display` modules.
         """
 
-        return tuple([module for module in self.modules
-                      if module.type == "display"])
+        return module_list(self._modules, "display")
 
     @property
     def envs(self) -> Tuple[Module]:
         """Tuple of connected :class:`~modi.module.env.Env` modules.
         """
 
-        return tuple([module for module in self.modules
-                      if module.type == "env"])
+        return module_list(self._modules, "env")
 
     @property
     def gyros(self) -> Tuple[Module]:
         """Tuple of connected :class:`~modi.module.gyro.Gyro` modules.
         """
 
-        return tuple([module for module in self.modules
-                      if module.type == "gyro"])
+        return module_list(self._modules, "gyro")
 
     @property
     def irs(self) -> Tuple[Module]:
         """Tuple of connected :class:`~modi.module.ir.Ir` modules.
         """
 
-        return tuple([module for module in self.modules
-                      if module.type == "ir"])
+        return module_list(self._modules, "ir")
 
     @property
     def leds(self) -> Tuple[Module]:
         """Tuple of connected :class:`~modi.module.led.Led` modules.
         """
 
-        return tuple([module for module in self.modules
-                      if module.type == "led"])
+        return module_list(self._modules, "led")
 
     @property
     def mics(self) -> Tuple[Module]:
         """Tuple of connected :class:`~modi.module.mic.Mic` modules.
         """
 
-        return tuple([module for module in self.modules
-                      if module.type == "mic"])
+        return module_list(self._modules, "mic")
 
     @property
     def motors(self) -> Tuple[Module]:
         """Tuple of connected :class:`~modi.module.motor.Motor` modules.
         """
 
-        return tuple([module for module in self.modules
-                      if module.type == "motor"])
+        return module_list(self._modules, "motor")
 
     @property
     def speakers(self) -> Tuple[Module]:
         """Tuple of connected :class:`~modi.module.speaker.Speaker` modules.
         """
 
-        return tuple([module for module in self.modules
-                      if module.type == "speaker"])
+        return module_list(self._modules, "speaker")
 
     @property
     def ultrasonics(self) -> Tuple[Module]:
         """Tuple of connected :class:`~modi.module.ultrasonic.Ultrasonic` modules.
         """
 
-        return tuple([module for module in self.modules
-                      if module.type == "ultrasonic"])
+        return module_list(self._modules, "ultrasonic")

--- a/modi/modi.py
+++ b/modi/modi.py
@@ -12,8 +12,6 @@ from typing import Tuple
 from modi._conn_proc import ConnProc
 from modi._exe_thrd import ExeThrd
 
-from modi.module.module import Module
-
 from modi.util.topology_manager import TopologyManager
 from modi.util.firmware_updater import FirmwareUpdater
 from modi.util.stranger import check_complete
@@ -27,7 +25,7 @@ class MODI:
     >>> bundle = modi.MODI()
     """
 
-    def __init__(self, nb_modules: int = 1, conn_mode: str = "serial",
+    def __init__(self, nb_modules: int = None, conn_mode: str = "serial",
                  module_uuid: str = "", test: bool = False,
                  verbose: bool = False):
 
@@ -35,7 +33,7 @@ class MODI:
 
         self._module_ids = dict()
         self._topology_data = dict()
-
+        self.__lazy = not nb_modules
         self._recv_q = mp.Queue()
         self._send_q = mp.Queue()
 
@@ -96,12 +94,13 @@ class MODI:
         init_flag.wait()
 
         self._topology_manager = TopologyManager(self._topology_data)
+        if nb_modules:
+            module_init_flag.wait()
+            if not module_init_flag.is_set():
+                raise Exception("Modules are not initialized properly!")
+                exit(1)
+            print("MODI modules are initialized!")
 
-        # module_init_flag.wait()
-        # if not module_init_flag.is_set():
-        #     raise Exception("Modules are not initialized properly!")
-        #     exit(1)
-        # print("MODI modules are initialized!")
         check_complete(self)
 
     def update_module_firmware(self) -> None:
@@ -126,7 +125,7 @@ class MODI:
         self._topology_manager.print_topology_map(print_id)
 
     @property
-    def modules(self) -> Tuple[Module]:
+    def modules(self) -> Tuple:
         """Tuple of connected modules except network module.
         Example:
         >>> bundle = modi.MODI()
@@ -135,77 +134,77 @@ class MODI:
         return tuple(self._modules)
 
     @property
-    def buttons(self) -> Tuple[Module]:
+    def buttons(self) -> module_list:
         """Tuple of connected :class:`~modi.module.button.Button` modules.
         """
-        return module_list(self._modules, 'button')
+        return module_list(self._modules, 'button', self.__lazy)
 
     @property
-    def dials(self) -> Tuple[Module]:
+    def dials(self) -> module_list:
         """Tuple of connected :class:`~modi.module.dial.Dial` modules.
         """
 
-        return module_list(self._modules, "dial")
+        return module_list(self._modules, "dial", self.__lazy)
 
     @property
-    def displays(self) -> Tuple[Module]:
+    def displays(self) -> module_list:
         """Tuple of connected :class:`~modi.module.display.Display` modules.
         """
 
-        return module_list(self._modules, "display")
+        return module_list(self._modules, "display", self.__lazy)
 
     @property
-    def envs(self) -> Tuple[Module]:
+    def envs(self) -> module_list:
         """Tuple of connected :class:`~modi.module.env.Env` modules.
         """
 
-        return module_list(self._modules, "env")
+        return module_list(self._modules, "env", self.__lazy)
 
     @property
-    def gyros(self) -> Tuple[Module]:
+    def gyros(self) -> module_list:
         """Tuple of connected :class:`~modi.module.gyro.Gyro` modules.
         """
 
-        return module_list(self._modules, "gyro")
+        return module_list(self._modules, "gyro", self.__lazy)
 
     @property
-    def irs(self) -> Tuple[Module]:
+    def irs(self) -> module_list:
         """Tuple of connected :class:`~modi.module.ir.Ir` modules.
         """
 
-        return module_list(self._modules, "ir")
+        return module_list(self._modules, "ir", self.__lazy)
 
     @property
-    def leds(self) -> Tuple[Module]:
+    def leds(self) -> module_list:
         """Tuple of connected :class:`~modi.module.led.Led` modules.
         """
 
-        return module_list(self._modules, "led")
+        return module_list(self._modules, "led", self.__lazy)
 
     @property
-    def mics(self) -> Tuple[Module]:
+    def mics(self) -> module_list:
         """Tuple of connected :class:`~modi.module.mic.Mic` modules.
         """
 
-        return module_list(self._modules, "mic")
+        return module_list(self._modules, "mic", self.__lazy)
 
     @property
-    def motors(self) -> Tuple[Module]:
+    def motors(self) -> module_list:
         """Tuple of connected :class:`~modi.module.motor.Motor` modules.
         """
 
-        return module_list(self._modules, "motor")
+        return module_list(self._modules, "motor", self.__lazy)
 
     @property
-    def speakers(self) -> Tuple[Module]:
+    def speakers(self) -> module_list:
         """Tuple of connected :class:`~modi.module.speaker.Speaker` modules.
         """
 
-        return module_list(self._modules, "speaker")
+        return module_list(self._modules, "speaker", self.__lazy)
 
     @property
-    def ultrasonics(self) -> Tuple[Module]:
+    def ultrasonics(self) -> module_list:
         """Tuple of connected :class:`~modi.module.ultrasonic.Ultrasonic` modules.
         """
 
-        return module_list(self._modules, "ultrasonic")
+        return module_list(self._modules, "ultrasonic", self.__lazy)

--- a/modi/task/exe_task.py
+++ b/modi/task/exe_task.py
@@ -102,11 +102,13 @@ class ExeTask:
 
         # TODO: Remove this if and elif branches
         if stream_state == self.firmware_updater.State.CRC_ERROR.value:
-            self.firmware_updater.update_response(response=True, is_error_response=True)
+            self.firmware_updater.update_response(response=True,
+                                                  is_error_response=True)
         elif stream_state == self.firmware_updater.State.CRC_COMPLETE.value:
             self.firmware_updater.update_response(response=True)
         elif stream_state == self.firmware_updater.State.ERASE_ERROR.value:
-            self.firmware_updater.update_response(response=True, is_error_response=True)
+            self.firmware_updater.update_response(response=True,
+                                                  is_error_response=True)
         elif stream_state == self.firmware_updater.State.ERASE_COMPLETE.value:
             self.firmware_updater.update_response(response=True)
 
@@ -304,8 +306,17 @@ class ExeTask:
                     module_id=module_instance.id,
                     module_pnp_state=Module.State.PNP_OFF
                 )
+
+                # Reboot module
+                reboot_message = self.__set_module_state(
+                    module_id, Module.State.REBOOT, Module.State.PNP_OFF
+                )
+                self._send_q.put(reboot_message)
+
+                self.__delay()
                 self._modules.append(module_instance)
-                print(str(type(module_instance))+" has been connected!")
+                print(f"{type(module_instance).__name__} ({module_id}) "
+                      f"has been connected!")
 
                 if self.__is_all_connected():
                     self._init_event.set()

--- a/modi/util/misc.py
+++ b/modi/util/misc.py
@@ -1,0 +1,18 @@
+import time
+
+
+class module_list(list):
+
+    def __init__(self, src, module_type):
+        super().__init__(src)
+        self.__src = src
+        self.__module_type = module_type
+
+    def __getitem__(self, item):
+        sublist = [module for module in self.__src
+                   if module.type == self.__module_type]
+        while not len(sublist) > item:
+            sublist = [module for module in self.__src
+                       if module.type == self.__module_type]
+            time.sleep(0.1)
+        return sublist[item]

--- a/modi/util/misc.py
+++ b/modi/util/misc.py
@@ -3,16 +3,20 @@ import time
 
 class module_list(list):
 
-    def __init__(self, src, module_type):
-        super().__init__(src)
+    def __init__(self, src, module_type, lazy=True):
         self.__src = src
         self.__module_type = module_type
+        self.__lazy = lazy
+        super().__init__(self.sublist())
 
     def __getitem__(self, item):
-        sublist = [module for module in self.__src
-                   if module.type == self.__module_type]
-        while not len(sublist) > item:
-            sublist = [module for module in self.__src
-                       if module.type == self.__module_type]
-            time.sleep(0.1)
-        return sublist[item]
+        if self.__lazy:
+            while not len(self.sublist()) > item:
+                time.sleep(0.1)
+            return self.sublist()[item]
+        else:
+            return super().__getitem__(item)
+
+    def sublist(self):
+        return [module for module in self.__src
+                if module.type == self.__module_type]

--- a/tests/test_modi.py
+++ b/tests/test_modi.py
@@ -21,6 +21,8 @@ from modi.module.output_module.led import Led
 from modi.module.output_module.motor import Motor
 from modi.module.output_module.speaker import Speaker
 
+from modi.util.misc import module_list
+
 
 class TestModi(unittest.TestCase):
     """Tests for 'modi' class."""
@@ -71,112 +73,112 @@ class TestModi(unittest.TestCase):
     def test_get_buttons(self):
         """Test buttons getter method."""
         actual_modules = self.modi.buttons
-        expected_modules = tuple(
-            [m for m in self.modi.modules if isinstance(m, Button)]
+        expected_modules = module_list(
+            self.modi.modules, 'button'
         )
 
-        self.assertIsInstance(actual_modules, tuple)
-        self.assertTupleEqual(actual_modules, expected_modules)
+        self.assertIsInstance(actual_modules, module_list)
+        self.assertEqual(actual_modules, expected_modules)
 
     def test_get_dials(self):
         """Test dials getter method."""
         actual_modules = self.modi.dials
-        expected_modules = tuple(
-            [m for m in self.modi.modules if isinstance(m, Dial)]
+        expected_modules = module_list(
+            self.modi.modules, 'dial'
         )
 
-        self.assertIsInstance(actual_modules, tuple)
-        self.assertTupleEqual(actual_modules, expected_modules)
+        self.assertIsInstance(actual_modules, module_list)
+        self.assertEqual(actual_modules, expected_modules)
 
     def test_get_envs(self):
         """Test envs getter method."""
         actual_modules = self.modi.envs
-        expected_modules = tuple(
-            [m for m in self.modi.modules if isinstance(m, Env)]
+        expected_modules = module_list(
+            self.modi.modules, 'env'
         )
 
-        self.assertIsInstance(actual_modules, tuple)
-        self.assertTupleEqual(actual_modules, expected_modules)
+        self.assertIsInstance(actual_modules, module_list)
+        self.assertEqual(actual_modules, expected_modules)
 
     def test_get_gyros(self):
         """Test gyros getter method."""
         actual_modules = self.modi.gyros
-        expected_modules = tuple(
-            [m for m in self.modi.modules if isinstance(m, Gyro)]
+        expected_modules = module_list(
+            self.modi.modules, 'gyro'
         )
 
-        self.assertIsInstance(actual_modules, tuple)
-        self.assertTupleEqual(actual_modules, expected_modules)
+        self.assertIsInstance(actual_modules, module_list)
+        self.assertEqual(actual_modules, expected_modules)
 
     def test_get_irs(self):
         """Test irs getter method."""
         actual_modules = self.modi.irs
-        expected_modules = tuple(
-            [m for m in self.modi.modules if isinstance(m, Ir)]
+        expected_modules = module_list(
+            self.modi.modules, 'ir'
         )
 
-        self.assertIsInstance(actual_modules, tuple)
-        self.assertTupleEqual(actual_modules, expected_modules)
+        self.assertIsInstance(actual_modules, module_list)
+        self.assertEqual(actual_modules, expected_modules)
 
     def test_get_mics(self):
         """Test mics getter method."""
         actual_modules = self.modi.mics
-        expected_modules = tuple(
-            [m for m in self.modi.modules if isinstance(m, Mic)]
+        expected_modules = module_list(
+            self.modi.modules, 'mic'
         )
 
-        self.assertIsInstance(actual_modules, tuple)
-        self.assertTupleEqual(actual_modules, expected_modules)
+        self.assertIsInstance(actual_modules, module_list)
+        self.assertEqual(actual_modules, expected_modules)
 
     def test_get_ultrasonics(self):
         """Test ultrasonics getter method."""
         actual_modules = self.modi.ultrasonics
-        expected_modules = tuple(
-            [m for m in self.modi.modules if isinstance(m, Ultrasonic)]
+        expected_modules = module_list(
+            self.modi.modules, 'ultrasonic'
         )
 
-        self.assertIsInstance(actual_modules, tuple)
-        self.assertTupleEqual(actual_modules, expected_modules)
+        self.assertIsInstance(actual_modules, module_list)
+        self.assertEqual(actual_modules, expected_modules)
 
     def test_get_displays(self):
         """Test displays getter method."""
         actual_modules = self.modi.displays
-        expected_modules = tuple(
-            [m for m in self.modi.modules if isinstance(m, Display)]
+        expected_modules = module_list(
+            self.modi.modules, 'display'
         )
 
-        self.assertIsInstance(actual_modules, tuple)
-        self.assertTupleEqual(actual_modules, expected_modules)
+        self.assertIsInstance(actual_modules, module_list)
+        self.assertEqual(actual_modules, expected_modules)
 
     def test_get_leds(self):
         """Test leds getter method."""
         actual_modules = self.modi.leds
-        expected_modules = tuple(
-            [m for m in self.modi.modules if isinstance(m, Led)]
+        expected_modules = module_list(
+            self.modi.modules, 'led'
         )
 
-        self.assertIsInstance(actual_modules, tuple)
-        self.assertTupleEqual(actual_modules, expected_modules)
+        self.assertIsInstance(actual_modules, module_list)
+        self.assertEqual(actual_modules, expected_modules)
 
     def test_get_motors(self):
         """Test motors getter method."""
         actual_modules = self.modi.motors
-        expected_modules = tuple(
-            [m for m in self.modi.modules if isinstance(m, Motor)]
+        expected_modules = module_list(
+            self.modi.modules, 'motor'
         )
 
-        self.assertIsInstance(actual_modules, tuple)
-        self.assertTupleEqual(actual_modules, expected_modules)
+        self.assertIsInstance(actual_modules, module_list)
+        self.assertEqual(actual_modules, expected_modules)
 
     def test_get_speakers(self):
         """Test speakers getter method."""
         actual_modules = self.modi.speakers
-        expected_modules = tuple(
-            [m for m in self.modi.modules if isinstance(m, Speaker)]
+        expected_modules = module_list(
+            self.modi.modules, 'speaker'
         )
 
-        self.assertIsInstance(actual_modules, tuple)
-        self.assertTupleEqual(actual_modules, expected_modules)
+        self.assertIsInstance(actual_modules, module_list)
+        self.assertEqual(actual_modules, expected_modules)
 
     # def test_print_topology_map(self):
     #     """Test print_topology_map method"""


### PR DESCRIPTION
Features include,

1. Add module_list class which inherits built-in list class
2. Enable feature that modi object can be initialized without specifying the number of modules
3. Fix getter methods of modules so that it waits until the module is initialized