### PR TITLE
Enable negative valule for speed and torque

### DIFF
--- a/modi/module/output_module/motor.py
+++ b/modi/module/output_module/motor.py
@@ -69,7 +69,8 @@ class Motor(OutputModule):
         :type degree_value: int
         :return: None
         """
-        self.degree = degree_value, self.second_degree
+        _ = self.first_degree
+        self.set_motor_channel(0, 2, degree_value)
 
     @property
     def second_degree(self) -> float:
@@ -89,7 +90,8 @@ class Motor(OutputModule):
         :type degree_value
         :return: None
         """
-        self.degree = self.first_degree, degree_value
+        _ = self.second_degree
+        self.set_motor_channel(1, 2, degree_value)
 
     @property
     def first_speed(self) -> float:
@@ -108,7 +110,8 @@ class Motor(OutputModule):
         :param speed_value: Angular speed to set the first motor.
         :return: None
         """
-        self.speed = speed_value, self.second_speed
+        _ = self.first_speed
+        self.set_motor_channel(0, 1, speed_value)
 
     @property
     def second_speed(self) -> float:
@@ -127,7 +130,8 @@ class Motor(OutputModule):
         :param speed_value: Angular speed to set the second motor.
         :return: None
         """
-        self.speed = self.first_speed, speed_value
+        _ = self.second_speed
+        self.set_motor_channel(1, 1, speed_value)
 
     @property
     def first_torque(self) -> float:
@@ -147,7 +151,8 @@ class Motor(OutputModule):
         :type torque_value: int
         :return: None
         """
-        self.torque = torque_value, self.second_torque
+        _ = self.first_torque
+        self.set_motor_channel(0, 0, torque_value)
 
     @property
     def second_torque(self) -> float:
@@ -167,7 +172,8 @@ class Motor(OutputModule):
         :type torque_value: int
         :return: None
         """
-        self.torque = self.first_torque, torque_value
+        _ = self.second_torque
+        self.set_motor_channel(1, 0, torque_value)
 
     @property
     def torque(self) -> Tuple[float, float]:

--- a/modi/module/output_module/motor.py
+++ b/modi/module/output_module/motor.py
@@ -46,7 +46,7 @@ class Motor(OutputModule):
             (
                 motor_channel,
                 control_mode,
-                control_value,
+                control_value if control_value >= 0 else -control_value,
                 0x00 if control_value >= 0 else 0xFFFF,
             ),
         )
@@ -101,7 +101,7 @@ class Motor(OutputModule):
         return self._get_property(self.PropertyType.FIRST_SPEED)
 
     @first_speed.setter
-    @OutputModule._validate_property(nb_values=1, value_range=(0, 100))
+    @OutputModule._validate_property(nb_values=1, value_range=(-100, 100))
     def first_speed(self, speed_value: int) -> None:
         """Set the speed of the motor at channel I
 
@@ -120,7 +120,7 @@ class Motor(OutputModule):
         return self._get_property(self.PropertyType.SECOND_SPEED)
 
     @second_speed.setter
-    @OutputModule._validate_property(nb_values=1, value_range=(0, 100))
+    @OutputModule._validate_property(nb_values=1, value_range=(-100, 100))
     def second_speed(self, speed_value: int) -> None:
         """Set the speed of the motor at channel II
 
@@ -139,7 +139,7 @@ class Motor(OutputModule):
         return self._get_property(self.PropertyType.FIRST_TORQUE)
 
     @first_torque.setter
-    @OutputModule._validate_property(nb_values=1, value_range=(0, 100))
+    @OutputModule._validate_property(nb_values=1, value_range=(-100, 100))
     def first_torque(self, torque_value: int) -> None:
         """Set the torque of the motor at channel I
 
@@ -159,7 +159,7 @@ class Motor(OutputModule):
         return self._get_property(self.PropertyType.SECOND_TORQUE)
 
     @second_torque.setter
-    @OutputModule._validate_property(nb_values=1, value_range=(0, 100))
+    @OutputModule._validate_property(nb_values=1, value_range=(-100, 100))
     def second_torque(self, torque_value: int) -> None:
         """Set the torque of the motor at channel II
 
@@ -182,7 +182,7 @@ class Motor(OutputModule):
         )
 
     @torque.setter
-    @OutputModule._validate_property(nb_values=2, value_range=(0, 100))
+    @OutputModule._validate_property(nb_values=2, value_range=(-100, 100))
     def torque(self, torque_value: Tuple[int, int]) -> None:
         """Set the torque of the motors at both channels
 
@@ -206,7 +206,7 @@ class Motor(OutputModule):
         )
 
     @speed.setter
-    @OutputModule._validate_property(2, (0, 100))
+    @OutputModule._validate_property(2, (-100, 100))
     def speed(self, speed_value: Tuple[int, int]) -> None:
         """Set the speed of the motors at both channels
 

--- a/tests/module/output_module_tests/test_motor.py
+++ b/tests/module/output_module_tests/test_motor.py
@@ -52,7 +52,7 @@ class TestMotor(unittest.TestCase):
 
     def test_set_first_torque(self):
         """Test set_first_torque method."""
-        first_torque_value, second_torque_value = 50, 0
+        first_torque_value = 50
         self.motor.first_torque = first_torque_value
         sent_messages = []
         while not self.send_q.empty():
@@ -61,34 +61,20 @@ class TestMotor(unittest.TestCase):
             Motor.request_property(
                 -1, Motor.PropertyType.FIRST_TORQUE) in sent_messages)
         self.assertTrue(
-            Motor.request_property(
-                -1, Motor.PropertyType.SECOND_TORQUE) in sent_messages)
-        self.assertTrue(
             parse_message(0x04, 19, -1, parse_data(
                 (0, 0, first_torque_value, 0), 'int'
-            )) in sent_messages)
-        self.assertTrue(
-            parse_message(0x04, 19, -1, parse_data(
-                (1, 0, second_torque_value, 0), 'int'
             )) in sent_messages)
 
     def test_set_second_torque(self):
         """Test set_second_torque method."""
-        first_torque_value, second_torque_value = 0, 50
+        second_torque_value = 50
         self.motor.second_torque = second_torque_value
         sent_messages = []
         while not self.send_q.empty():
             sent_messages.append(self.send_q.get_nowait())
         self.assertTrue(
             Motor.request_property(
-                -1, Motor.PropertyType.FIRST_TORQUE) in sent_messages)
-        self.assertTrue(
-            Motor.request_property(
                 -1, Motor.PropertyType.SECOND_TORQUE) in sent_messages)
-        self.assertTrue(
-            parse_message(0x04, 19, -1, parse_data(
-                (0, 0, first_torque_value, 0), 'int'
-            )) in sent_messages)
         self.assertTrue(
             parse_message(0x04, 19, -1, parse_data(
                 (1, 0, second_torque_value, 0), 'int'
@@ -164,9 +150,6 @@ class TestMotor(unittest.TestCase):
             Motor.request_property(
                 -1, Motor.PropertyType.FIRST_SPEED) in sent_messages)
         self.assertTrue(
-            Motor.request_property(
-                -1, Motor.PropertyType.SECOND_SPEED) in sent_messages)
-        self.assertTrue(
             parse_message(0x04, 19, -1, parse_data(
                 (0, 1, first_speed_value, 0), 'int'
             )) in sent_messages)
@@ -178,9 +161,6 @@ class TestMotor(unittest.TestCase):
         sent_messages = []
         while not self.send_q.empty():
             sent_messages.append(self.send_q.get_nowait())
-        self.assertTrue(
-            Motor.request_property(
-                -1, Motor.PropertyType.FIRST_SPEED) in sent_messages)
         self.assertTrue(
             Motor.request_property(
                 -1, Motor.PropertyType.SECOND_SPEED) in sent_messages)
@@ -259,9 +239,6 @@ class TestMotor(unittest.TestCase):
             Motor.request_property(
                 -1, Motor.PropertyType.FIRST_DEGREE) in sent_messages)
         self.assertTrue(
-            Motor.request_property(
-                -1, Motor.PropertyType.SECOND_DEGREE) in sent_messages)
-        self.assertTrue(
             parse_message(0x04, 19, -1, parse_data(
                 (0, 2, first_degree_value, 0), 'int'
             )) in sent_messages)
@@ -273,9 +250,6 @@ class TestMotor(unittest.TestCase):
         sent_messages = []
         while not self.send_q.empty():
             sent_messages.append(self.send_q.get_nowait())
-        self.assertTrue(
-            Motor.request_property(
-                -1, Motor.PropertyType.FIRST_DEGREE) in sent_messages)
         self.assertTrue(
             Motor.request_property(
                 -1, Motor.PropertyType.SECOND_DEGREE) in sent_messages)


### PR DESCRIPTION
##### - Summary
Enable negative values for the motor module

##### - Related Issues

##### - PR Overview
- [ ] This PR closes one of the issues [y/n] (issue #issue_number_here)
- [ ] This PR requires new unit tests [y/n] (please make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (please make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]


