### PR TITLE
Add explicit delay after get_property and set_property

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@
 name: Build Status
 
 on:
-  [ "push" ]
+  [ "push", "pull_request" ]
 
 jobs:
   build:

--- a/modi/module/module.py
+++ b/modi/module/module.py
@@ -100,7 +100,7 @@ class Module:
             )
             self._msg_send_q.put(modi_serialtemp)
             self._properties[property_type].last_request_time = time.time()
-
+        time.sleep(0.001)
         return self._properties[property_type].value
 
     def update_property(self, property_type: IntEnum,

--- a/modi/module/output_module/output_module.py
+++ b/modi/module/output_module/output_module.py
@@ -1,3 +1,5 @@
+import time
+
 from enum import IntEnum
 from typing import Tuple, List
 from modi.module.module import Module
@@ -79,6 +81,7 @@ class OutputModule(Module):
 
         for message in messages:
             self._msg_send_q.put(message)
+        time.sleep(0.001)
 
     @staticmethod
     def _validate_property(nb_values: int, value_range: Tuple = None):


### PR DESCRIPTION
##### - Summary
Add explicit delay after get_property and set_property

##### - Related Issues

##### - PR Overview
- [ ] This PR closes one of the issues [y/n] (issue #issue_number_here)
- [ ] This PR requires new unit tests [y/n] (please make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (please make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]


