### PR TITLE
Add teams notification at new release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,16 +28,3 @@ jobs:
         python -m unittest
     - name: Run convention tests
       run: python -m flake8 modi tests
-    - name: Microsoft Teams Notification
-      uses: jdcargile/ms-teams-notification@v1.2
-      with:
-        # GitHub Token
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        # Microsoft Teams Webhook URI
-        ms-teams-webhook-uri: https://outlook.office.com/webhook/6a71efde-c9bd-46f3-a4a3-a40b25bfa5d4@ac338f03-1812-4534-b284-4284315b0fa9/IncomingWebhook/87b82fad1c5846ae8823c38fe01a97c2/f7ddc081-fea9-4879-a490-f45d7dc8a387
-        # Message to be sent to Microsoft Teams channel
-        notification-summary: PyMODI Build Notification
-        # Color of notification header line
-        notification-color: 17a2b8
-        # Timezone (ex. America/Denver)
-        timezone: Korea/Seoul

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,3 +28,16 @@ jobs:
         python -m unittest
     - name: Run convention tests
       run: python -m flake8 modi tests
+    - name: Microsoft Teams Notification
+      uses: jdcargile/ms-teams-notification@v1.2
+      with:
+        # GitHub Token
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        # Microsoft Teams Webhook URI
+        ms-teams-webhook-uri: https://outlook.office.com/webhook/6a71efde-c9bd-46f3-a4a3-a40b25bfa5d4@ac338f03-1812-4534-b284-4284315b0fa9/IncomingWebhook/87b82fad1c5846ae8823c38fe01a97c2/f7ddc081-fea9-4879-a490-f45d7dc8a387
+        # Message to be sent to Microsoft Teams channel
+        notification-summary: PyMODI Build Notification
+        # Color of notification header line
+        notification-color: 17a2b8
+        # Timezone (ex. America/Denver)
+        timezone: Korea/Seoul

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,3 +56,16 @@ jobs:
         body: file://HISTORY.md
         to: tech@luxrobo.com
         from: PyMODI
+    - name: Microsoft Teams Notification
+      uses: jdcargile/ms-teams-notification@v1.2
+      with:
+        # GitHub Token
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        # Microsoft Teams Webhook URI
+        ms-teams-webhook-uri: ${{ secrets.TEAMS_WEBHOOK }}
+        # Message to be sent to Microsoft Teams channel
+        notification-summary: A new version of PyMODI is released!!
+        # Color of notification header line
+        notification-color: 17a2b8
+        # Timezone (ex. America/Denver)
+        timezone: Korea/Seoul


### PR DESCRIPTION
##### - Summary
Add teams notification at new release

##### - Related Issues
The maintainer should add new secrets for the github repo

##### - PR Overview
- [ ] This PR closes one of the issues [y/n] (issue #issue_number_here)
- [ ] This PR requires new unit tests [y/n] (please make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (please make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]


