### PR TITLE
Fix bumpversion config not to make tag

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 current_version = 0.9.0
 commit = True
-tag = True
+tag = False
 
 [bumpversion:file:./modi/about.py]
 search = __version__ = "{current_version}"


### PR DESCRIPTION
##### - Summary
Fix bumpversion config not to make tag

##### - Related Issues

##### - PR Overview
- [ ] This PR closes one of the issues [y/n] (issue #issue_number_here)
- [ ] This PR requires new unit tests [y/n] (please make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (please make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]


