### PR TITLE
Change can task to singleton

### DIFF
--- a/modi/task/can_task.py
+++ b/modi/task/can_task.py
@@ -12,8 +12,12 @@ from modi.task.conn_task import ConnTask
 
 class CanTask(ConnTask):
 
+    _instances = set()
+
     def __init__(self, can_recv_q, can_send_q, verbose, port=None):
         print("Run Can Task.")
+        if CanTask._instances:
+            raise Exception("can0 device already in use")
         self._can_recv_q = can_recv_q
         self._can_send_q = can_send_q
 


### PR DESCRIPTION
##### - Summary
1. Prevent creating multiple can_task objects 

##### - Related Issues

##### - PR Overview
- [ ] This PR closes one of the issues [y/n] (issue #issue_number_here)
- [ ] This PR requires new unit tests [y/n] (please make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (please make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]


