### PR TITLE
Handle battery module

### DIFF
--- a/modi/__main__.py
+++ b/modi/__main__.py
@@ -9,7 +9,6 @@ import modi
 from modi.util.tutor import Tutor
 from modi.firmware_updater import STM32FirmwareUpdater
 from modi.util.msgutil import parse_message, decode_message
-from modi.debugger import Debugger
 
 
 def check_option(*options):
@@ -94,6 +93,7 @@ if __name__ == "__main__":
         print(">>> bundle = modi.MODI()")
         init_time = time.time()
         if check_option('-g', '--gui'):
+            from modi.debugger import Debugger
             bundle = Debugger()
             bundle.start()
         else:

--- a/modi/__main__.py
+++ b/modi/__main__.py
@@ -9,6 +9,7 @@ import modi
 from modi.util.tutor import Tutor
 from modi.firmware_updater import STM32FirmwareUpdater
 from modi.util.msgutil import parse_message, decode_message
+from modi.debugger import Debugger
 
 
 def check_option(*options):
@@ -31,15 +32,14 @@ if __name__ == "__main__":
                 "\n-d, --debug: Auto initialize debugging mode" \
                 "\n     Usage: python -m modi --debug -n <nb_modules>" \
                 "\n     options: -u, --update: update the module firmware" \
-                "\n              -n, --nb_moodules: number of modules" \
                 " connected to the network module" \
                 "\n     If you want to use debugger in an interactive shell," \
                 " use: python -im modi -n <nb_modules> -<options>"
 
     try:
-        opts, args = getopt(sys.argv[1:], 'tdn:uhvp',
-                            ["tutorial", "debug", "nb_modules=", "update",
-                             "help", "verbose", "performance"])
+        opts, args = getopt(sys.argv[1:], 'tduhvpg',
+                            ["tutorial", "debug", "update",
+                             "help", "verbose", "performance", "gui"])
     except GetoptError as err:
         print(str(err))
         print(usage)
@@ -90,20 +90,16 @@ if __name__ == "__main__":
         exit(0)
 
     if check_option('-d', '--debug'):
-        nb_modules = check_option('-n', '--nb_modules')
         is_update = check_option('-u', '--update')
-        nb_modules = int(nb_modules)
-        print(">>> bundle = modi.MODI(" + str(nb_modules) + ")")
+        print(">>> bundle = modi.MODI()")
         init_time = time.time()
-        if nb_modules:
-            bundle = modi.MODI(nb_modules, verbose=check_option('-v',
-                                                                '--verbose'))
+        if check_option('-g', '--gui'):
+            bundle = Debugger()
+            bundle.start()
         else:
             bundle = modi.MODI(verbose=check_option('-v', '--verbose'))
         fin_time = time.time()
-
         print(f'Took {fin_time - init_time:.2f} seconds to finish the job')
-
         print(">>>")
 
         for module in bundle.modules:

--- a/modi/module/setup_module/battery.py
+++ b/modi/module/setup_module/battery.py
@@ -1,10 +1,7 @@
-"""Network module."""
-
-from enum import IntEnum
+"""Battery module."""
 
 from modi.module.setup_module.setup_module import SetupModule
 
 
 class Battery(SetupModule):
-    class PropertyType(IntEnum):
-        RESERVED = 0
+    pass

--- a/modi/module/setup_module/battery.py
+++ b/modi/module/setup_module/battery.py
@@ -1,0 +1,10 @@
+"""Network module."""
+
+from enum import IntEnum
+
+from modi.module.setup_module.setup_module import SetupModule
+
+
+class Battery(SetupModule):
+    class PropertyType(IntEnum):
+        RESERVED = 0

--- a/modi/task/exe_task.py
+++ b/modi/task/exe_task.py
@@ -81,7 +81,7 @@ class ExeTask:
                 if 0 < topology_ids[idx] < 0xFFFF else None
             if topology_ids[idx] == 0 and not self.__is_battery_connected:
                 print(f"{'#'*58}\nBattery module detected!! "
-                      f"Please remove the battery module.\n{'#'*58}")
+                      f"Topology may be incomplete.\n{'#'*58}")
                 self.__is_battery_connected = True
                 self._modules.append(Battery(-1, -1, self._conn))
 

--- a/modi/task/exe_task.py
+++ b/modi/task/exe_task.py
@@ -16,7 +16,7 @@ class ExeTask:
         self._modules = modules
         self._topology_data = topology_data
         self._conn = conn_task
-
+        self.__is_battery_connected = False
         # Reboot all modules
         self.__set_module_state(
             BROADCAST_ID, Module.State.REBOOT, Module.State.PNP_OFF
@@ -77,7 +77,11 @@ class ExeTask:
 
         for idx, direction in enumerate(('r', 't', 'l', 'b')):
             topology_by_id[direction] = topology_ids[idx] \
-                if topology_ids[idx] != 0xFFFF else None
+                if 0 < topology_ids[idx] < 0xFFFF else None
+            if topology_ids[idx] == 0 and not self.__is_battery_connected:
+                print("Battery module detected!! "
+                      "Please remove the battery module.")
+                self.__is_battery_connected = True
 
         # Update topology data for the module
         self._topology_data[src_id] = topology_by_id

--- a/modi/task/exe_task.py
+++ b/modi/task/exe_task.py
@@ -5,6 +5,7 @@ from typing import Callable, Dict, Union
 from enum import IntEnum
 
 from modi.module.module import Module, BROADCAST_ID
+from modi.module.setup_module.battery import Battery
 from modi.util.misc import get_module_from_name, get_module_type_from_uuid
 from modi.util.msgutil import unpack_data, decode_data, parse_message
 from modi.util.conn_util import is_network_module_connected
@@ -79,9 +80,10 @@ class ExeTask:
             topology_by_id[direction] = topology_ids[idx] \
                 if 0 < topology_ids[idx] < 0xFFFF else None
             if topology_ids[idx] == 0 and not self.__is_battery_connected:
-                print("Battery module detected!! "
-                      "Please remove the battery module.")
+                print(f"{'#'*58}\nBattery module detected!! "
+                      f"Please remove the battery module.\n{'#'*58}")
                 self.__is_battery_connected = True
+                self._modules.append(Battery(-1, -1, self._conn))
 
         # Update topology data for the module
         self._topology_data[src_id] = topology_by_id

--- a/modi/util/topology_manager.py
+++ b/modi/util/topology_manager.py
@@ -1,3 +1,4 @@
+import time
 from typing import Dict, List, Tuple
 
 from modi.util.misc import module_list
@@ -205,6 +206,12 @@ class TopologyManager:
         return True
 
     def is_topology_complete(self):
+        for i, module in enumerate(self._modules):
+            if module.id < 0:
+                self._modules.pop(i)
+                time.sleep(2)
+                return True
+
         if len(self._tp_data) < 1:
             return False
         try:


### PR DESCRIPTION
##### - Summary
1. Ignore battery module when topology data contains battery
2. Wait 2 seconds before initialization when battery module is connected
3. Print warning message if battery module is connected

##### - Related Issues

##### - PR Overview
- [ ] This PR closes one of the issues [y/n] (issue #issue_number_here)
- [ ] This PR requires new unit tests [y/n] (please make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (please make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]


