### PR TITLE
Remove enum dependency from pymodi

### DIFF
--- a/modi/module/input_module/button.py
+++ b/modi/module/input_module/button.py
@@ -1,17 +1,14 @@
 """Button module."""
 
-from enum import IntEnum
-
 from modi.module.input_module.input_module import InputModule
 
 
 class Button(InputModule):
 
-    class PropertyType(IntEnum):
-        CLICKED = 2
-        DOUBLE_CLICKED = 3
-        PRESSED = 4
-        TOGGLED = 5
+    CLICKED = 2
+    DOUBLE_CLICKED = 3
+    PRESSED = 4
+    TOGGLED = 5
 
     @property
     def clicked(self) -> bool:
@@ -20,7 +17,7 @@ class Button(InputModule):
         :return: `True` if clicked or `False`.
         :rtype: bool
         """
-        return self._get_property(self.PropertyType.CLICKED) == 100.
+        return self._get_property(Button.CLICKED) == 100.
 
     @property
     def double_clicked(self) -> bool:
@@ -29,7 +26,7 @@ class Button(InputModule):
         :return: `True` if double clicked or `False`.
         :rtype: bool
         """
-        return self._get_property(self.PropertyType.DOUBLE_CLICKED) == 100.
+        return self._get_property(Button.DOUBLE_CLICKED) == 100.
 
     @property
     def pressed(self) -> bool:
@@ -38,7 +35,7 @@ class Button(InputModule):
         :return: `True` if pressed or `False`.
         :rtype: bool
         """
-        return self._get_property(self.PropertyType.PRESSED) == 100.
+        return self._get_property(Button.PRESSED) == 100.
 
     @property
     def toggled(self) -> bool:
@@ -47,4 +44,4 @@ class Button(InputModule):
         :return: `True` if toggled or `False`.
         :rtype: bool
         """
-        return self._get_property(self.PropertyType.TOGGLED) == 100.
+        return self._get_property(Button.TOGGLED) == 100.

--- a/modi/module/input_module/dial.py
+++ b/modi/module/input_module/dial.py
@@ -1,15 +1,12 @@
 """Dial module."""
 
-from enum import IntEnum
-
 from modi.module.input_module.input_module import InputModule
 
 
 class Dial(InputModule):
 
-    class PropertyType(IntEnum):
-        DEGREE = 2
-        TURNSPEED = 3
+    DEGREE = 2
+    TURNSPEED = 3
 
     @property
     def degree(self) -> float:
@@ -18,7 +15,7 @@ class Dial(InputModule):
         :return: The dial's angle.
         :rtype: float
         """
-        return self._get_property(self.PropertyType.DEGREE)
+        return self._get_property(Dial.DEGREE)
 
     @property
     def turnspeed(self) -> float:
@@ -27,4 +24,4 @@ class Dial(InputModule):
         :return: The dial's turn speed.
         :rtype: float
         """
-        return self._get_property(self.PropertyType.TURNSPEED)
+        return self._get_property(Dial.TURNSPEED)

--- a/modi/module/input_module/env.py
+++ b/modi/module/input_module/env.py
@@ -1,19 +1,16 @@
 """Env module."""
 
-from enum import IntEnum
-
 from modi.module.input_module.input_module import InputModule
 
 
 class Env(InputModule):
 
-    class PropertyType(IntEnum):
-        TEMPERATURE = 6
-        HUMIDITY = 7
-        BRIGHTNESS = 2
-        RED = 3
-        GREEN = 4
-        BLUE = 5
+    TEMPERATURE = 6
+    HUMIDITY = 7
+    BRIGHTNESS = 2
+    RED = 3
+    GREEN = 4
+    BLUE = 5
 
     @property
     def temperature(self) -> float:
@@ -22,7 +19,7 @@ class Env(InputModule):
         :return: Temperature.
         :rtype: float
         """
-        return self._get_property(self.PropertyType.TEMPERATURE)
+        return self._get_property(Env.TEMPERATURE)
 
     @property
     def humidity(self) -> float:
@@ -31,7 +28,7 @@ class Env(InputModule):
         :return: Humidity.
         :rtype: float
         """
-        return self._get_property(self.PropertyType.HUMIDITY)
+        return self._get_property(Env.HUMIDITY)
 
     @property
     def brightness(self) -> float:
@@ -40,7 +37,7 @@ class Env(InputModule):
         :return: Brightness.
         :rtype: float
         """
-        return self._get_property(self.PropertyType.BRIGHTNESS)
+        return self._get_property(Env.BRIGHTNESS)
 
     @property
     def red(self) -> float:
@@ -49,7 +46,7 @@ class Env(InputModule):
         :return: Red component of light.
         :rtype: float
         """
-        return self._get_property(self.PropertyType.RED)
+        return self._get_property(Env.RED)
 
     @property
     def green(self) -> float:
@@ -58,7 +55,7 @@ class Env(InputModule):
         :return: Green component of light.
         :rtype: float
         """
-        return self._get_property(self.PropertyType.GREEN)
+        return self._get_property(Env.GREEN)
 
     @property
     def blue(self) -> float:
@@ -67,4 +64,4 @@ class Env(InputModule):
         :return: Blue component of light.
         :rtype: float
         """
-        return self._get_property(self.PropertyType.BLUE)
+        return self._get_property(Env.BLUE)

--- a/modi/module/input_module/gyro.py
+++ b/modi/module/input_module/gyro.py
@@ -1,23 +1,20 @@
 """Gyro module."""
 
-from enum import IntEnum
-
 from modi.module.input_module.input_module import InputModule
 
 
 class Gyro(InputModule):
 
-    class PropertyType(IntEnum):
-        ROLL = 2
-        PITCH = 3
-        YAW = 4
-        ANGULAR_VEL_X = 5
-        ANGULAR_VEL_Y = 6
-        ANGULAR_VEL_Z = 7
-        ACCELERATION_X = 8
-        ACCELERATION_Y = 9
-        ACCELERATION_Z = 10
-        VIBRATION = 11
+    ROLL = 2
+    PITCH = 3
+    YAW = 4
+    ANGULAR_VEL_X = 5
+    ANGULAR_VEL_Y = 6
+    ANGULAR_VEL_Z = 7
+    ACCELERATION_X = 8
+    ACCELERATION_Y = 9
+    ACCELERATION_Z = 10
+    VIBRATION = 11
 
     @property
     def roll(self) -> float:
@@ -27,7 +24,7 @@ class Gyro(InputModule):
         :rtype: float
         """
 
-        return self._get_property(self.PropertyType.ROLL)
+        return self._get_property(Gyro.ROLL)
 
     @property
     def pitch(self) -> float:
@@ -37,7 +34,7 @@ class Gyro(InputModule):
         :rtype: float
         """
 
-        return self._get_property(self.PropertyType.PITCH)
+        return self._get_property(Gyro.PITCH)
 
     @property
     def yaw(self) -> float:
@@ -47,7 +44,7 @@ class Gyro(InputModule):
         :rtype: float
         """
 
-        return self._get_property(self.PropertyType.YAW)
+        return self._get_property(Gyro.YAW)
 
     @property
     def angular_vel_x(self) -> float:
@@ -57,7 +54,7 @@ class Gyro(InputModule):
         :rtype: float
         """
 
-        return self._get_property(self.PropertyType.ANGULAR_VEL_X)
+        return self._get_property(Gyro.ANGULAR_VEL_X)
 
     @property
     def angular_vel_y(self) -> float:
@@ -67,7 +64,7 @@ class Gyro(InputModule):
         :rtype: float
         """
 
-        return self._get_property(self.PropertyType.ANGULAR_VEL_Y)
+        return self._get_property(Gyro.ANGULAR_VEL_Y)
 
     @property
     def angular_vel_z(self) -> float:
@@ -77,7 +74,7 @@ class Gyro(InputModule):
         :rtype: float
         """
 
-        return self._get_property(self.PropertyType.ANGULAR_VEL_Z)
+        return self._get_property(Gyro.ANGULAR_VEL_Z)
 
     @property
     def acceleration_x(self) -> float:
@@ -87,7 +84,7 @@ class Gyro(InputModule):
         :rtype: float
         """
 
-        return self._get_property(self.PropertyType.ACCELERATION_X)
+        return self._get_property(Gyro.ACCELERATION_X)
 
     @property
     def acceleration_y(self) -> float:
@@ -97,7 +94,7 @@ class Gyro(InputModule):
         :rtype: float
         """
 
-        return self._get_property(self.PropertyType.ACCELERATION_Y)
+        return self._get_property(Gyro.ACCELERATION_Y)
 
     @property
     def acceleration_z(self) -> float:
@@ -107,7 +104,7 @@ class Gyro(InputModule):
         :rtype: float
         """
 
-        return self._get_property(self.PropertyType.ACCELERATION_Z)
+        return self._get_property(Gyro.ACCELERATION_Z)
 
     @property
     def vibration(self) -> float:
@@ -117,4 +114,4 @@ class Gyro(InputModule):
         :rtype: float
         """
 
-        return self._get_property(self.PropertyType.VIBRATION)
+        return self._get_property(Gyro.VIBRATION)

--- a/modi/module/input_module/ir.py
+++ b/modi/module/input_module/ir.py
@@ -1,14 +1,11 @@
 """IR module."""
 
-from enum import IntEnum
-
 from modi.module.input_module.input_module import InputModule
 
 
 class Ir(InputModule):
 
-    class PropertyType(IntEnum):
-        PROXIMITY = 2
+    PROXIMITY = 2
 
     @property
     def proximity(self) -> float:
@@ -17,4 +14,4 @@ class Ir(InputModule):
         :return: Distance to object.
         :rtype: float
         """
-        return self._get_property(self.PropertyType.PROXIMITY)
+        return self._get_property(Ir.PROXIMITY)

--- a/modi/module/input_module/mic.py
+++ b/modi/module/input_module/mic.py
@@ -1,15 +1,12 @@
 """Mic module."""
 
-from enum import IntEnum
-
 from modi.module.input_module.input_module import InputModule
 
 
 class Mic(InputModule):
 
-    class PropertyType(IntEnum):
-        VOLUME = 2
-        FREQUENCY = 3
+    VOLUME = 2
+    FREQUENCY = 3
 
     @property
     def volume(self) -> float:
@@ -18,7 +15,7 @@ class Mic(InputModule):
         :return: Volume of input sound.
         :rtype: float
         """
-        return self._get_property(self.PropertyType.VOLUME)
+        return self._get_property(Mic.VOLUME)
 
     @property
     def frequency(self) -> float:
@@ -27,4 +24,4 @@ class Mic(InputModule):
         :return: Frequency of input sound.
         :rtype: float
         """
-        return self._get_property(self.PropertyType.FREQUENCY)
+        return self._get_property(Mic.FREQUENCY)

--- a/modi/module/input_module/ultrasonic.py
+++ b/modi/module/input_module/ultrasonic.py
@@ -1,14 +1,11 @@
 """Ultrasonic module."""
 
-from enum import IntEnum
-
 from modi.module.input_module.input_module import InputModule
 
 
 class Ultrasonic(InputModule):
 
-    class PropertyType(IntEnum):
-        DISTANCE = 2
+    DISTANCE = 2
 
     @property
     def distance(self) -> float:
@@ -17,4 +14,4 @@ class Ultrasonic(InputModule):
         :return: Distance to object.
         :rtype: float
         """
-        return self._get_property(self.PropertyType.DISTANCE)
+        return self._get_property(Ultrasonic.DISTANCE)

--- a/modi/module/module.py
+++ b/modi/module/module.py
@@ -110,7 +110,7 @@ class Module:
         """ Get module property value and request
 
         :param property_type: Type of the requested property
-        :type property_type: IntEnum
+        :type property_type: int
         """
 
         # Register property if not exists
@@ -130,7 +130,7 @@ class Module:
         """ Update property value and time
 
         :param property_type: Type of the updated property
-        :type property_type: IntEnum
+        :type property_type: int
         :param property_value: Value to update the property
         :type property_value: float
         """

--- a/modi/module/module.py
+++ b/modi/module/module.py
@@ -4,8 +4,6 @@ import time
 from typing import Union
 from os import path
 
-from enum import IntEnum
-
 from modi.util.msgutil import parse_message
 
 BROADCAST_ID = 0xFFF
@@ -22,16 +20,15 @@ class Module:
             self.value = value
             self.last_update_time = time.time()
 
-    class State(IntEnum):
-        RUN = 0
-        WARNING = 1
-        FORCED_PAUSE = 2
-        ERROR_STOP = 3
-        UPDATE_FIRMWARE = 4
-        UPDATE_FIRMWARE_READY = 5
-        REBOOT = 6
-        PNP_ON = 1
-        PNP_OFF = 2
+    RUN = 0
+    WARNING = 1
+    FORCED_PAUSE = 2
+    ERROR_STOP = 3
+    UPDATE_FIRMWARE = 4
+    UPDATE_FIRMWARE_READY = 5
+    REBOOT = 6
+    PNP_ON = 1
+    PNP_OFF = 2
 
     def __init__(self, id_, uuid, conn_task):
         self._id = id_
@@ -109,7 +106,7 @@ class Module:
         )
         return latest_version <= self.__version
 
-    def _get_property(self, property_type: IntEnum) -> float:
+    def _get_property(self, property_type: int) -> float:
         """ Get module property value and request
 
         :param property_type: Type of the requested property
@@ -128,7 +125,7 @@ class Module:
 
         return self._properties[property_type].value
 
-    def update_property(self, property_type: IntEnum,
+    def update_property(self, property_type: int,
                         property_value: float) -> None:
         """ Update property value and time
 
@@ -143,7 +140,7 @@ class Module:
         self._properties[property_type].last_update_time = time.time()
 
     def __request_property(self, destination_id: int,
-                           property_type: IntEnum) -> None:
+                           property_type: int) -> None:
         """ Generate message for request property
 
         :param destination_id: Id of the destination module

--- a/modi/module/output_module/display.py
+++ b/modi/module/output_module/display.py
@@ -1,17 +1,15 @@
 """Display module."""
 
-from enum import IntEnum
-
 from modi.module.output_module.output_module import OutputModule
 
 
 class Display(OutputModule):
-    class PropertyType(IntEnum):
-        TEXT = 17
-        CLEAR = 21
-        VARIABLE = 22
-        SET_HORIZONTAL = 25
-        SET_VERTICAL = 26
+
+    TEXT = 17
+    CLEAR = 21
+    VARIABLE = 22
+    SET_HORIZONTAL = 25
+    SET_VERTICAL = 26
 
     def __init__(self, id_, uuid, msg_send_q):
         super().__init__(id_, uuid, msg_send_q)
@@ -34,9 +32,9 @@ class Display(OutputModule):
         self.clear()
         self._set_property(
             self._id,
-            self.PropertyType.TEXT,
+            Display.TEXT,
             str(text)[:27],  # Only 27 characters can be shown on the display
-            self.PropertyDataType.STRING
+            OutputModule.STRING
         )
         self._text = text
 
@@ -57,9 +55,9 @@ class Display(OutputModule):
         """
         self._set_property(
             self._id,
-            self.PropertyType.VARIABLE,
+            Display.VARIABLE,
             (variable, position_x, position_y),
-            self.PropertyDataType.DISPLAY_VAR,
+            OutputModule.DISPLAY_VAR,
         )
         self._text += str(variable)
 
@@ -72,8 +70,8 @@ class Display(OutputModule):
         """
         self._set_property(
             self.id,
-            self.PropertyType.SET_HORIZONTAL, (offset, ),
-            self.PropertyDataType.FLOAT,
+            Display.SET_HORIZONTAL, (offset, ),
+            OutputModule.FLOAT,
         )
 
     def set_vertical(self, offset) -> None:
@@ -85,8 +83,8 @@ class Display(OutputModule):
         """
         self._set_property(
             self.id,
-            self.PropertyType.SET_VERTICAL, (offset, ),
-            self.PropertyDataType.FLOAT,
+            Display.SET_VERTICAL, (offset, ),
+            OutputModule.FLOAT,
         )
 
     def clear(self) -> None:
@@ -97,8 +95,8 @@ class Display(OutputModule):
         """
         self._set_property(
             self._id,
-            self.PropertyType.CLEAR,
-            bytes(2),
-            self.PropertyDataType.RAW
+            Display.CLEAR,
+            (0, 0),
+            OutputModule.RAW
         )
         self._text = ""

--- a/modi/module/output_module/led.py
+++ b/modi/module/output_module/led.py
@@ -1,19 +1,16 @@
 """Led module."""
 
-from enum import IntEnum
 from typing import Tuple
 from modi.module.output_module.output_module import OutputModule
 
 
 class Led(OutputModule):
 
-    class PropertyType(IntEnum):
-        RED = 2
-        GREEN = 3
-        BLUE = 4
+    RED = 2
+    GREEN = 3
+    BLUE = 4
 
-    class CommandType(IntEnum):
-        SET_RGB = 16
+    SET_RGB = 16
 
     @property
     def rgb(self) -> Tuple[float, float, float]:
@@ -33,12 +30,12 @@ class Led(OutputModule):
             return
         self._set_property(
             self._id,
-            self.CommandType.SET_RGB,
+            Led.SET_RGB,
             color,
         )
-        self.update_property(self.PropertyType.RED, color[0])
-        self.update_property(self.PropertyType.GREEN, color[1])
-        self.update_property(self.PropertyType.BLUE, color[2])
+        self.update_property(Led.RED, color[0])
+        self.update_property(Led.GREEN, color[1])
+        self.update_property(Led.BLUE, color[2])
 
     def turn_on(self) -> None:
         """Turn on led at maximum brightness.
@@ -62,7 +59,7 @@ class Led(OutputModule):
         :return: Red component
         :rtype: float
         """
-        return self._get_property(self.PropertyType.RED)
+        return self._get_property(Led.RED)
 
     @red.setter
     @OutputModule._validate_property(nb_values=1, value_range=(0, 255))
@@ -82,7 +79,7 @@ class Led(OutputModule):
         :return: Green component
         :rtype: float
         """
-        return self._get_property(self.PropertyType.GREEN)
+        return self._get_property(Led.GREEN)
 
     @green.setter
     @OutputModule._validate_property(nb_values=1, value_range=(0, 255))
@@ -102,7 +99,7 @@ class Led(OutputModule):
         :return: Blue component
         :rtype: float
         """
-        return self._get_property(self.PropertyType.BLUE)
+        return self._get_property(Led.BLUE)
 
     @blue.setter
     @OutputModule._validate_property(nb_values=1, value_range=(0, 255))

--- a/modi/module/output_module/motor.py
+++ b/modi/module/output_module/motor.py
@@ -1,25 +1,22 @@
 """Motor module."""
 
-from enum import IntEnum
 from typing import Tuple
 from modi.module.output_module.output_module import OutputModule
 
 
 class Motor(OutputModule):
 
-    class PropertyType(IntEnum):
-        FIRST_TORQUE = 2
-        SECOND_TORQUE = 10
-        FIRST_SPEED = 3
-        SECOND_SPEED = 11
-        FIRST_DEGREE = 4
-        SECOND_DEGREE = 12
+    FIRST_TORQUE = 2
+    SECOND_TORQUE = 10
+    FIRST_SPEED = 3
+    SECOND_SPEED = 11
+    FIRST_DEGREE = 4
+    SECOND_DEGREE = 12
 
-    class ControlType(IntEnum):
-        TORQUE = 16
-        SPEED = 17
-        DEGREE = 18
-        CHANNEL = 19
+    TORQUE = 16
+    SPEED = 17
+    DEGREE = 18
+    CHANNEL = 19
 
     def set_motor_channel(self,
                           motor_channel: int, control_mode: int,
@@ -38,7 +35,7 @@ class Motor(OutputModule):
         """
         self._set_property(
             self._id,
-            self.ControlType.CHANNEL,
+            Motor.CHANNEL,
             (
                 motor_channel,
                 control_mode,
@@ -53,7 +50,7 @@ class Motor(OutputModule):
         :return: first degree value
         :rtype: float
         """
-        return self._get_property(self.PropertyType.FIRST_DEGREE)
+        return self._get_property(Motor.FIRST_DEGREE)
 
     @first_degree.setter
     @OutputModule._validate_property(nb_values=1, value_range=(0, 100))
@@ -66,7 +63,7 @@ class Motor(OutputModule):
         """
         _ = self.first_degree
         self.set_motor_channel(0, 2, degree_value)
-        self.update_property(self.PropertyType.FIRST_DEGREE, degree_value)
+        self.update_property(Motor.FIRST_DEGREE, degree_value)
 
     @property
     def second_degree(self) -> float:
@@ -75,7 +72,7 @@ class Motor(OutputModule):
         :return: second degree value
         :rtype: float
         """
-        return self._get_property(self.PropertyType.SECOND_DEGREE)
+        return self._get_property(Motor.SECOND_DEGREE)
 
     @second_degree.setter
     @OutputModule._validate_property(nb_values=1, value_range=(0, 100))
@@ -88,7 +85,7 @@ class Motor(OutputModule):
         """
         _ = self.second_degree
         self.set_motor_channel(1, 2, degree_value)
-        self.update_property(self.PropertyType.SECOND_DEGREE, degree_value)
+        self.update_property(Motor.SECOND_DEGREE, degree_value)
 
     @property
     def first_speed(self) -> float:
@@ -97,7 +94,7 @@ class Motor(OutputModule):
         :return: first speed value
         :rtype: float
         """
-        return self._get_property(self.PropertyType.FIRST_SPEED)
+        return self._get_property(Motor.FIRST_SPEED)
 
     @first_speed.setter
     @OutputModule._validate_property(nb_values=1, value_range=(-100, 100))
@@ -109,7 +106,7 @@ class Motor(OutputModule):
         """
         _ = self.first_speed
         self.set_motor_channel(0, 1, speed_value)
-        self.update_property(self.PropertyType.FIRST_SPEED, speed_value)
+        self.update_property(Motor.FIRST_SPEED, speed_value)
 
     @property
     def second_speed(self) -> float:
@@ -118,7 +115,7 @@ class Motor(OutputModule):
         :return: second speed value
         :rtype: float
         """
-        return self._get_property(self.PropertyType.SECOND_SPEED)
+        return self._get_property(Motor.SECOND_SPEED)
 
     @second_speed.setter
     @OutputModule._validate_property(nb_values=1, value_range=(-100, 100))
@@ -130,7 +127,7 @@ class Motor(OutputModule):
         """
         _ = self.second_speed
         self.set_motor_channel(1, 1, speed_value)
-        self.update_property(self.PropertyType.SECOND_SPEED, speed_value)
+        self.update_property(Motor.SECOND_SPEED, speed_value)
 
     @property
     def first_torque(self) -> float:
@@ -139,7 +136,7 @@ class Motor(OutputModule):
         :return: first torque value
         :rtype: float
         """
-        return self._get_property(self.PropertyType.FIRST_TORQUE)
+        return self._get_property(Motor.FIRST_TORQUE)
 
     @first_torque.setter
     @OutputModule._validate_property(nb_values=1, value_range=(-100, 100))
@@ -153,11 +150,11 @@ class Motor(OutputModule):
         _ = self.first_torque
         self._set_property(
             self.id,
-            self.ControlType.TORQUE,
+            Motor.TORQUE,
             (torque_value, self.second_torque),
         )
         # self.set_motor_channel(0, 0, torque_value)
-        self.update_property(self.PropertyType.FIRST_TORQUE, torque_value)
+        self.update_property(Motor.FIRST_TORQUE, torque_value)
 
     @property
     def second_torque(self) -> float:
@@ -166,7 +163,7 @@ class Motor(OutputModule):
         :return: second torque value
         :rtype: float
         """
-        return self._get_property(self.PropertyType.SECOND_TORQUE)
+        return self._get_property(Motor.SECOND_TORQUE)
 
     @second_torque.setter
     @OutputModule._validate_property(nb_values=1, value_range=(-100, 100))
@@ -180,11 +177,11 @@ class Motor(OutputModule):
         _ = self.second_torque
         self._set_property(
             self.id,
-            self.ControlType.TORQUE,
+            Motor.TORQUE,
             (self.first_torque, torque_value),
         )
         # self.set_motor_channel(1, 0, torque_value)
-        self.update_property(self.PropertyType.SECOND_TORQUE, torque_value)
+        self.update_property(Motor.SECOND_TORQUE, torque_value)
 
     @property
     def torque(self) -> Tuple[float, float]:
@@ -194,8 +191,8 @@ class Motor(OutputModule):
         :rtype: Tuple[float, float]
         """
         return (
-            self._get_property(self.PropertyType.FIRST_TORQUE),
-            self._get_property(self.PropertyType.SECOND_TORQUE),
+            self._get_property(Motor.FIRST_TORQUE),
+            self._get_property(Motor.SECOND_TORQUE),
         )
 
     @torque.setter
@@ -210,13 +207,13 @@ class Motor(OutputModule):
         _ = self.torque
         self._set_property(
             self.id,
-            self.ControlType.TORQUE,
+            Motor.TORQUE,
             torque_value,
         )
         # self.set_motor_channel(0, 0, torque_value[0])
         # self.set_motor_channel(1, 0, torque_value[1])
-        self.update_property(self.PropertyType.FIRST_TORQUE, torque_value[0])
-        self.update_property(self.PropertyType.SECOND_TORQUE, torque_value[1])
+        self.update_property(Motor.FIRST_TORQUE, torque_value[0])
+        self.update_property(Motor.SECOND_TORQUE, torque_value[1])
 
     @property
     def speed(self):
@@ -225,8 +222,8 @@ class Motor(OutputModule):
         :return: Tuple[float, float]
         """
         return (
-            self._get_property(self.PropertyType.FIRST_SPEED),
-            self._get_property(self.PropertyType.SECOND_SPEED),
+            self._get_property(Motor.FIRST_SPEED),
+            self._get_property(Motor.SECOND_SPEED),
         )
 
     @speed.setter
@@ -241,8 +238,8 @@ class Motor(OutputModule):
         _ = self.speed
         self.set_motor_channel(0, 1, speed_value[0])
         self.set_motor_channel(1, 1, speed_value[1])
-        self.update_property(self.PropertyType.FIRST_SPEED, speed_value[0])
-        self.update_property(self.PropertyType.SECOND_SPEED, speed_value[1])
+        self.update_property(Motor.FIRST_SPEED, speed_value[0])
+        self.update_property(Motor.SECOND_SPEED, speed_value[1])
 
     @property
     def degree(self) -> Tuple[float, float]:
@@ -252,8 +249,8 @@ class Motor(OutputModule):
         :rtype: float
         """
         return (
-            self._get_property(self.PropertyType.FIRST_DEGREE),
-            self._get_property(self.PropertyType.SECOND_DEGREE),
+            self._get_property(Motor.FIRST_DEGREE),
+            self._get_property(Motor.SECOND_DEGREE),
         )
 
     @degree.setter
@@ -268,5 +265,5 @@ class Motor(OutputModule):
         _ = self.degree
         self.set_motor_channel(0, 2, degree_value[0])
         self.set_motor_channel(1, 2, degree_value[1])
-        self.update_property(self.PropertyType.FIRST_DEGREE, degree_value[0])
-        self.update_property(self.PropertyType.SECOND_DEGREE, degree_value[1])
+        self.update_property(Motor.FIRST_DEGREE, degree_value[0])
+        self.update_property(Motor.SECOND_DEGREE, degree_value[1])

--- a/modi/module/output_module/output_module.py
+++ b/modi/module/output_module/output_module.py
@@ -1,48 +1,48 @@
 import time
 
-from enum import IntEnum
-from typing import Tuple, List
+from typing import Tuple, List, Union
 from modi.module.module import Module
 from modi.util.msgutil import parse_message, parse_data
 
 
 class OutputModule(Module):
-    class PropertyDataType(IntEnum):
-        INT = 0
-        FLOAT = 1
-        STRING = 2
-        RAW = 3
-        DISPLAY_VAR = 4
 
-    def __parse_set_message(self, destination_id: int,
-                            property_type: IntEnum,
+    INT = 0
+    FLOAT = 1
+    STRING = 2
+    RAW = 3
+    DISPLAY_VAR = 4
+
+    @staticmethod
+    def __parse_set_message(destination_id: int,
+                            property_type: int,
                             property_values: Tuple,
-                            property_data_type: IntEnum) -> List[str]:
+                            property_data_type: int) -> List[str]:
         """Generate set_property json serialized message
 
         :param destination_id: Id of the destination module
         :type destination_id: int
         :param property_type: Property Type
-        :type property_type: IntEnum
+        :type property_type: int
         :param property_values: Property values
         :type property_values: Tuple
         :param property_data_type: Property Data Type
-        :type property_data_type: IntEnum
+        :type property_data_type: int
         :return: List of json messages
         :rtype: List[str]
         """
         data_list = []
-        if property_data_type == self.PropertyDataType.INT:
+        if property_data_type == OutputModule.INT:
             data_list.append(parse_data(property_values, 'int'))
-        elif property_data_type == self.PropertyDataType.FLOAT:
+        elif property_data_type == OutputModule.FLOAT:
             data_list.append(parse_data(property_values, 'float'))
-        elif property_data_type == self.PropertyDataType.STRING:
+        elif property_data_type == OutputModule.STRING:
             for i in range(0, len(property_values), 8):
                 chunk = str(property_values)[i:i + 8]
                 data_list.append(parse_data(chunk, 'string'))
-        elif property_data_type == self.PropertyDataType.RAW:
+        elif property_data_type == OutputModule.RAW:
             data_list.append(parse_data(property_values, 'raw'))
-        elif property_data_type == self.PropertyDataType.DISPLAY_VAR:
+        elif property_data_type == OutputModule.DISPLAY_VAR:
             data_list.append(parse_data(property_values, 'display_var'))
         else:
             raise RuntimeError("Not supported property data type.")
@@ -55,19 +55,19 @@ class OutputModule(Module):
         return messages
 
     def _set_property(self, destination_id: int,
-                      property_type: IntEnum, property_values: Tuple,
-                      property_data_type: IntEnum
-                      = PropertyDataType.INT) -> None:
+                      property_type: int, property_values: Union[Tuple, str],
+                      property_data_type: int
+                      = 0) -> None:
         """Send the message of set_property command to the module
 
         :param destination_id: Id of the destination module
         :type destination_id: int
         :param property_type: Property Type
-        :type property_type: IntEnum
+        :type property_type: int
         :param property_values: Property Values
         :type property_values: Tuple
         :param property_data_type: Property Data Type
-        :type property_data_type: IntEnum
+        :type property_data_type: int
         :return: None
         """
         messages = self.__parse_set_message(

--- a/modi/module/output_module/speaker.py
+++ b/modi/module/output_module/speaker.py
@@ -1,17 +1,15 @@
 """Speaker module."""
 
-from enum import IntEnum
 from typing import Tuple
 from modi.module.output_module.output_module import OutputModule
 
 
 class Speaker(OutputModule):
-    class PropertyType(IntEnum):
-        FREQUENCY = 3
-        VOLUME = 2
 
-    class CommandType(IntEnum):
-        SET_TUNE = 16
+    FREQUENCY = 3
+    VOLUME = 2
+
+    SET_TUNE = 16
 
     @property
     def tune(self) -> Tuple[float, float]:
@@ -33,16 +31,16 @@ class Speaker(OutputModule):
             return
         self._set_property(
             self._id,
-            self.CommandType.SET_TUNE,
+            Speaker.SET_TUNE,
             tune_value,
-            self.PropertyDataType.FLOAT,
+            OutputModule.FLOAT,
         )
-        self.update_property(self.PropertyType.FREQUENCY, tune_value[0])
-        self.update_property(self.PropertyType.VOLUME, tune_value[1])
+        self.update_property(Speaker.FREQUENCY, tune_value[0])
+        self.update_property(Speaker.VOLUME, tune_value[1])
 
     @property
     def frequency(self) -> float:
-        return self._get_property(self.PropertyType.FREQUENCY)
+        return self._get_property(Speaker.FREQUENCY)
 
     @frequency.setter
     @OutputModule._validate_property(nb_values=1)
@@ -62,7 +60,7 @@ class Speaker(OutputModule):
         :return: Volume value
         :rtype: float
         """
-        return self._get_property(self.PropertyType.VOLUME)
+        return self._get_property(Speaker.VOLUME)
 
     @volume.setter
     @OutputModule._validate_property(nb_values=1, value_range=(0, 100))

--- a/modi/module/setup_module/network.py
+++ b/modi/module/setup_module/network.py
@@ -1,31 +1,28 @@
 """Network module."""
 import time
 
-from enum import IntEnum
-
 from modi.module.setup_module.setup_module import SetupModule
 from modi.util.msgutil import parse_message
 
 
 class Network(SetupModule):
-    class PropertyType(IntEnum):
-        BUTTON = 3
-        JOYSTICK = 3
-        DIAL = 4
-        LEFT_SLIDER = 5
-        RIGHT_SLIDER = 6
-        TIMER = 7
-        BUTTON_CLICK = 0x0102
-        BUTTON_DOUBLE_CLICK = 0x0103
-        TOGGLE = 0x00104
 
-    class CommandType(IntEnum):
-        BUZZER = 0x0003
-        CAMERA = 0x0101
+    BUTTON = 3
+    JOYSTICK = 3
+    DIAL = 4
+    LEFT_SLIDER = 5
+    RIGHT_SLIDER = 6
+    TIMER = 7
+    BUTTON_CLICK = 0x0102
+    BUTTON_DOUBLE_CLICK = 0x0103
+    TOGGLE = 0x00104
+
+    BUZZER = 0x0003
+    CAMERA = 0x0101
 
     @property
     def button_pressed(self):
-        return self._get_property(self.PropertyType.BUTTON) == 100
+        return self._get_property(Network.BUTTON) == 100
 
     @property
     def joystick(self):
@@ -34,35 +31,35 @@ class Network(SetupModule):
             30.0: 'down',
             40.0: 'left',
             50.0: 'right',
-        }.get(self._get_property(self.PropertyType.JOYSTICK))
+        }.get(self._get_property(Network.JOYSTICK))
 
     @property
     def dial(self):
-        return self._get_property(self.PropertyType.DIAL)
+        return self._get_property(Network.DIAL)
 
     @property
     def left_slider(self):
-        return self._get_property(self.PropertyType.LEFT_SLIDER)
+        return self._get_property(Network.LEFT_SLIDER)
 
     @property
     def right_slider(self):
-        return self._get_property(self.PropertyType.RIGHT_SLIDER)
+        return self._get_property(Network.RIGHT_SLIDER)
 
     @property
     def timer(self):
-        return self._get_property(self.PropertyType.TIMER) == 100
+        return self._get_property(Network.TIMER) == 100
 
     @property
     def button_clicked(self):
-        return self._get_property(self.PropertyType.BUTTON_CLICK) == 100
+        return self._get_property(Network.BUTTON_CLICK) == 100
 
     @property
     def button_double_clicked(self):
-        return self._get_property(self.PropertyType.BUTTON_DOUBLE_CLICK) == 100
+        return self._get_property(Network.BUTTON_DOUBLE_CLICK) == 100
 
     @property
     def button_toggled(self):
-        return self._get_property(self.PropertyType.BUTTON.TOGGLE) == 100
+        return self._get_property(Network.TOGGLE) == 100
 
     def _set_property(self, command_type, value):
         self._conn.send(parse_message(
@@ -71,10 +68,10 @@ class Network(SetupModule):
         time.sleep(0.05)
 
     def take_picture(self):
-        self._set_property(self.CommandType.CAMERA, 100)
+        self._set_property(Network.CAMERA, 100)
 
     def buzzer_on(self):
-        self._set_property(self.CommandType.BUZZER, 100)
+        self._set_property(Network.BUZZER, 100)
 
     def buzzer_off(self):
-        self._set_property(self.CommandType.BUZZER, 0)
+        self._set_property(Network.BUZZER, 0)

--- a/modi/task/exe_task.py
+++ b/modi/task/exe_task.py
@@ -2,8 +2,6 @@ import json
 import time
 from typing import Callable, Dict, Union
 
-from enum import IntEnum
-
 from modi.module.module import Module, BROADCAST_ID
 from modi.module.setup_module.battery import Battery
 from modi.util.misc import get_module_from_name, get_module_type_from_uuid
@@ -19,7 +17,7 @@ class ExeTask:
         self.__is_battery_connected = False
         # Reboot all modules
         self.__set_module_state(
-            BROADCAST_ID, Module.State.REBOOT, Module.State.PNP_OFF
+            BROADCAST_ID, Module.REBOOT, Module.PNP_OFF
         )
         self.__request_network_uuid()
 
@@ -116,7 +114,7 @@ class ExeTask:
             # Turn off pnp if pnp flag is on
             if module.module_type != 'Network' and user_code_state < 2:
                 self.__set_module_state(
-                    module_id, Module.State.RUN, Module.State.PNP_OFF
+                    module_id, Module.RUN, Module.PNP_OFF
                 )
         # Disconnect module with no health message for more than 2 second
         for module in self._modules:
@@ -157,8 +155,8 @@ class ExeTask:
         module_instance = module_template(
             module_id, module_uuid, self._conn
         )
-        self.__set_module_state(module_instance.id, Module.State.RUN,
-                                Module.State.PNP_OFF)
+        self.__set_module_state(module_instance.id, Module.RUN,
+                                Module.PNP_OFF)
         module_instance.version = module_version_info
         self._modules.append(module_instance)
         print(f"{str(module_instance)} has been connected!")
@@ -184,8 +182,8 @@ class ExeTask:
         else:
             module.update_property(property_number, decode_data(data))
 
-    def __set_module_state(self, destination_id: int, module_state: IntEnum,
-                           pnp_state: IntEnum) -> None:
+    def __set_module_state(self, destination_id: int, module_state: int,
+                           pnp_state: int) -> None:
         """ Generate message for set module state and pnp state
 
         :param destination_id: Id to target destination
@@ -193,7 +191,7 @@ class ExeTask:
         :param module_state: State value of the module
         :type module_state: int
         :param pnp_state: Pnp state value
-        :type pnp_state: IntEnum
+        :type pnp_state: int
         :return: None
         """
         self._conn.send(parse_message(0x09, 0, destination_id,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pyserial
-enum34
 python-can
-esptool
 bleak
+esptool

--- a/tests/module/input_module_tests/test_button.py
+++ b/tests/module/input_module_tests/test_button.py
@@ -24,7 +24,7 @@ class TestButton(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Button.PropertyType.CLICKED, None, 95, None)))
+                          (Button.CLICKED, None, 95, None)))
 
     def test_get_double_clicked(self):
         """Test get_double_clicked method."""
@@ -32,7 +32,7 @@ class TestButton(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Button.PropertyType.DOUBLE_CLICKED,
+                          (Button.DOUBLE_CLICKED,
                            None, 95, None)))
 
     def test_get_pressed(self):
@@ -41,7 +41,7 @@ class TestButton(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Button.PropertyType.PRESSED, None, 95, None)))
+                          (Button.PRESSED, None, 95, None)))
 
     def test_get_toggled(self):
         """Test get_toggled method."""
@@ -49,7 +49,7 @@ class TestButton(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Button.PropertyType.TOGGLED, None, 95, None)))
+                          (Button.TOGGLED, None, 95, None)))
 
 
 if __name__ == "__main__":

--- a/tests/module/input_module_tests/test_dial.py
+++ b/tests/module/input_module_tests/test_dial.py
@@ -24,7 +24,7 @@ class TestDial(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Dial.PropertyType.DEGREE, None, 95, None))
+                          (Dial.DEGREE, None, 95, None))
         )
 
     def test_get_turnspeed(self):
@@ -33,7 +33,7 @@ class TestDial(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Dial.PropertyType.TURNSPEED, None, 95, None))
+                          (Dial.TURNSPEED, None, 95, None))
         )
 
 

--- a/tests/module/input_module_tests/test_env.py
+++ b/tests/module/input_module_tests/test_env.py
@@ -24,7 +24,7 @@ class TestEnv(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Env.PropertyType.TEMPERATURE, None, 95, None))
+                          (Env.TEMPERATURE, None, 95, None))
         )
 
     def test_get_humidity(self):
@@ -33,7 +33,7 @@ class TestEnv(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Env.PropertyType.HUMIDITY, None, 95, None))
+                          (Env.HUMIDITY, None, 95, None))
         )
 
     def test_get_brightness(self):
@@ -42,7 +42,7 @@ class TestEnv(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Env.PropertyType.BRIGHTNESS, None, 95, None))
+                          (Env.BRIGHTNESS, None, 95, None))
         )
 
     def test_get_red(self):
@@ -51,7 +51,7 @@ class TestEnv(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Env.PropertyType.RED, None, 95, None))
+                          (Env.RED, None, 95, None))
         )
 
     def test_get_green(self):
@@ -60,7 +60,7 @@ class TestEnv(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Env.PropertyType.GREEN, None, 95, None))
+                          (Env.GREEN, None, 95, None))
         )
 
     def test_get_blue(self):
@@ -69,7 +69,7 @@ class TestEnv(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Env.PropertyType.BLUE, None, 95, None))
+                          (Env.BLUE, None, 95, None))
         )
 
 

--- a/tests/module/input_module_tests/test_gyro.py
+++ b/tests/module/input_module_tests/test_gyro.py
@@ -24,7 +24,7 @@ class TestGyro(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Gyro.PropertyType.ROLL, None, 95, None))
+                          (Gyro.ROLL, None, 95, None))
         )
 
     def test_get_pitch(self):
@@ -33,7 +33,7 @@ class TestGyro(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Gyro.PropertyType.PITCH, None, 95, None))
+                          (Gyro.PITCH, None, 95, None))
         )
 
     def test_get_yaw(self):
@@ -42,7 +42,7 @@ class TestGyro(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Gyro.PropertyType.YAW, None, 95, None))
+                          (Gyro.YAW, None, 95, None))
         )
 
     def test_get_angular_vel_x(self):
@@ -51,7 +51,7 @@ class TestGyro(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Gyro.PropertyType.ANGULAR_VEL_X, None, 95, None))
+                          (Gyro.ANGULAR_VEL_X, None, 95, None))
         )
 
     def test_get_angular_vel_y(self):
@@ -60,7 +60,7 @@ class TestGyro(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Gyro.PropertyType.ANGULAR_VEL_Y, None, 95, None))
+                          (Gyro.ANGULAR_VEL_Y, None, 95, None))
         )
 
     def test_get_angular_vel_z(self):
@@ -69,7 +69,7 @@ class TestGyro(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Gyro.PropertyType.ANGULAR_VEL_Z, None, 95, None))
+                          (Gyro.ANGULAR_VEL_Z, None, 95, None))
         )
 
     def test_get_acceleration_x(self):
@@ -78,7 +78,7 @@ class TestGyro(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Gyro.PropertyType.ACCELERATION_X, None, 95, None))
+                          (Gyro.ACCELERATION_X, None, 95, None))
         )
 
     def test_get_acceleration_y(self):
@@ -87,7 +87,7 @@ class TestGyro(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Gyro.PropertyType.ACCELERATION_Y, None, 95, None))
+                          (Gyro.ACCELERATION_Y, None, 95, None))
         )
 
     def test_get_acceleration_z(self):
@@ -96,7 +96,7 @@ class TestGyro(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Gyro.PropertyType.ACCELERATION_Z, None, 95, None))
+                          (Gyro.ACCELERATION_Z, None, 95, None))
         )
 
     def test_get_vibration(self):
@@ -105,7 +105,7 @@ class TestGyro(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Gyro.PropertyType.VIBRATION, None, 95, None))
+                          (Gyro.VIBRATION, None, 95, None))
         )
 
 

--- a/tests/module/input_module_tests/test_ir.py
+++ b/tests/module/input_module_tests/test_ir.py
@@ -24,7 +24,7 @@ class TestIr(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Ir.PropertyType.PROXIMITY, None, 95, None))
+                          (Ir.PROXIMITY, None, 95, None))
         )
 
 

--- a/tests/module/input_module_tests/test_mic.py
+++ b/tests/module/input_module_tests/test_mic.py
@@ -25,7 +25,7 @@ class TestMic(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Mic.PropertyType.VOLUME, None, 95, None))
+                          (Mic.VOLUME, None, 95, None))
         )
 
     def test_get_frequency(self):
@@ -34,7 +34,7 @@ class TestMic(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Mic.PropertyType.FREQUENCY, None, 95, None))
+                          (Mic.FREQUENCY, None, 95, None))
         )
 
 

--- a/tests/module/input_module_tests/test_ultrasonic.py
+++ b/tests/module/input_module_tests/test_ultrasonic.py
@@ -24,7 +24,7 @@ class TestUltrasonic(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Ultrasonic.PropertyType.DISTANCE, None, 95, None))
+                          (Ultrasonic.DISTANCE, None, 95, None))
         )
 
 

--- a/tests/module/output_module_tests/test_led.py
+++ b/tests/module/output_module_tests/test_led.py
@@ -68,7 +68,7 @@ class TestLed(unittest.TestCase):
         _ = self.led.red
         self.assertEqual(
             self.conn.send_list[0],
-            parse_message(0x03, 0, -1, (Led.PropertyType.RED, None, 95, None)))
+            parse_message(0x03, 0, -1, (Led.RED, None, 95, None)))
 
     def test_set_green(self):
         """Test set_green method."""
@@ -87,7 +87,7 @@ class TestLed(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Led.PropertyType.GREEN, None, 95, None)))
+                          (Led.GREEN, None, 95, None)))
 
     def test_set_blue(self):
         """Test blue method."""
@@ -106,7 +106,7 @@ class TestLed(unittest.TestCase):
         self.assertEqual(
             self.conn.send_list[0],
             parse_message(0x03, 0, -1,
-                          (Led.PropertyType.BLUE, None, 95, None)))
+                          (Led.BLUE, None, 95, None)))
 
 
 if __name__ == "__main__":

--- a/tests/module/output_module_tests/test_motor.py
+++ b/tests/module/output_module_tests/test_motor.py
@@ -36,11 +36,11 @@ class TestMotor(unittest.TestCase):
         while self.conn.send_list:
             sent_messages.append(self.conn.send_list.pop())
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.FIRST_TORQUE,
+            parse_message(0x03, 0, -1, (Motor.FIRST_TORQUE,
                                         None, 95, None))
             in sent_messages)
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.SECOND_TORQUE,
+            parse_message(0x03, 0, -1, (Motor.SECOND_TORQUE,
                                         None, 95, None))
             in sent_messages)
         self.assertTrue(
@@ -56,7 +56,7 @@ class TestMotor(unittest.TestCase):
         while self.conn.send_list:
             sent_messages.append(self.conn.send_list.pop())
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.FIRST_TORQUE,
+            parse_message(0x03, 0, -1, (Motor.FIRST_TORQUE,
                                         None, 95, None))
             in sent_messages)
         self.assertTrue(
@@ -72,7 +72,7 @@ class TestMotor(unittest.TestCase):
         while self.conn.send_list:
             sent_messages.append(self.conn.send_list.pop())
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.SECOND_TORQUE,
+            parse_message(0x03, 0, -1, (Motor.SECOND_TORQUE,
                                         None, 95, None))
             in sent_messages)
         self.assertTrue(
@@ -87,11 +87,11 @@ class TestMotor(unittest.TestCase):
         while self.conn.send_list:
             sent_messages.append(self.conn.send_list.pop())
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.FIRST_TORQUE,
+            parse_message(0x03, 0, -1, (Motor.FIRST_TORQUE,
                                         None, 95, None))
             in sent_messages)
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.SECOND_TORQUE,
+            parse_message(0x03, 0, -1, (Motor.SECOND_TORQUE,
                                         None, 95, None))
             in sent_messages)
 
@@ -102,7 +102,7 @@ class TestMotor(unittest.TestCase):
         while self.conn.send_list:
             sent_messages.append(self.conn.send_list.pop())
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.FIRST_TORQUE,
+            parse_message(0x03, 0, -1, (Motor.FIRST_TORQUE,
                                         None, 95, None))
             in sent_messages)
 
@@ -113,7 +113,7 @@ class TestMotor(unittest.TestCase):
         while self.conn.send_list:
             sent_messages.append(self.conn.send_list.pop())
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.SECOND_TORQUE,
+            parse_message(0x03, 0, -1, (Motor.SECOND_TORQUE,
                                         None, 95, None))
             in sent_messages)
 
@@ -125,11 +125,11 @@ class TestMotor(unittest.TestCase):
         while self.conn.send_list:
             sent_messages.append(self.conn.send_list.pop())
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.FIRST_SPEED,
+            parse_message(0x03, 0, -1, (Motor.FIRST_SPEED,
                                         None, 95, None))
             in sent_messages)
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.SECOND_SPEED,
+            parse_message(0x03, 0, -1, (Motor.SECOND_SPEED,
                                         None, 95, None))
             in sent_messages)
         self.assertTrue(
@@ -149,7 +149,7 @@ class TestMotor(unittest.TestCase):
         while self.conn.send_list:
             sent_messages.append(self.conn.send_list.pop())
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.FIRST_SPEED,
+            parse_message(0x03, 0, -1, (Motor.FIRST_SPEED,
                                         None, 95, None))
             in sent_messages)
         self.assertTrue(
@@ -165,7 +165,7 @@ class TestMotor(unittest.TestCase):
         while self.conn.send_list:
             sent_messages.append(self.conn.send_list.pop())
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.SECOND_SPEED,
+            parse_message(0x03, 0, -1, (Motor.SECOND_SPEED,
                                         None, 95, None))
             in sent_messages)
         self.assertTrue(
@@ -180,11 +180,11 @@ class TestMotor(unittest.TestCase):
         while self.conn.send_list:
             sent_messages.append(self.conn.send_list.pop())
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.FIRST_SPEED,
+            parse_message(0x03, 0, -1, (Motor.FIRST_SPEED,
                                         None, 95, None))
             in sent_messages)
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.SECOND_SPEED,
+            parse_message(0x03, 0, -1, (Motor.SECOND_SPEED,
                                         None, 95, None))
             in sent_messages)
 
@@ -195,7 +195,7 @@ class TestMotor(unittest.TestCase):
         while self.conn.send_list:
             sent_messages.append(self.conn.send_list.pop())
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.FIRST_SPEED,
+            parse_message(0x03, 0, -1, (Motor.FIRST_SPEED,
                                         None, 95, None))
             in sent_messages)
 
@@ -206,7 +206,7 @@ class TestMotor(unittest.TestCase):
         while self.conn.send_list:
             sent_messages.append(self.conn.send_list.pop())
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.SECOND_SPEED,
+            parse_message(0x03, 0, -1, (Motor.SECOND_SPEED,
                                         None, 95, None))
             in sent_messages)
 
@@ -218,11 +218,11 @@ class TestMotor(unittest.TestCase):
         while self.conn.send_list:
             sent_messages.append(self.conn.send_list.pop())
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.FIRST_DEGREE,
+            parse_message(0x03, 0, -1, (Motor.FIRST_DEGREE,
                                         None, 95, None))
             in sent_messages)
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.SECOND_DEGREE,
+            parse_message(0x03, 0, -1, (Motor.SECOND_DEGREE,
                                         None, 95, None))
             in sent_messages)
         self.assertTrue(
@@ -242,7 +242,7 @@ class TestMotor(unittest.TestCase):
         while self.conn.send_list:
             sent_messages.append(self.conn.send_list.pop())
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.FIRST_DEGREE,
+            parse_message(0x03, 0, -1, (Motor.FIRST_DEGREE,
                                         None, 95, None))
             in sent_messages)
         self.assertTrue(
@@ -258,7 +258,7 @@ class TestMotor(unittest.TestCase):
         while self.conn.send_list:
             sent_messages.append(self.conn.send_list.pop())
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.SECOND_DEGREE,
+            parse_message(0x03, 0, -1, (Motor.SECOND_DEGREE,
                                         None, 95, None))
             in sent_messages)
         self.assertTrue(
@@ -273,11 +273,11 @@ class TestMotor(unittest.TestCase):
         while self.conn.send_list:
             sent_messages.append(self.conn.send_list.pop())
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.FIRST_DEGREE,
+            parse_message(0x03, 0, -1, (Motor.FIRST_DEGREE,
                                         None, 95, None))
             in sent_messages)
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.SECOND_DEGREE,
+            parse_message(0x03, 0, -1, (Motor.SECOND_DEGREE,
                                         None, 95, None))
             in sent_messages)
 
@@ -288,7 +288,7 @@ class TestMotor(unittest.TestCase):
         while self.conn.send_list:
             sent_messages.append(self.conn.send_list.pop())
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.FIRST_DEGREE,
+            parse_message(0x03, 0, -1, (Motor.FIRST_DEGREE,
                                         None, 95, None))
             in sent_messages)
 
@@ -299,7 +299,7 @@ class TestMotor(unittest.TestCase):
         while self.conn.send_list:
             sent_messages.append(self.conn.send_list.pop())
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Motor.PropertyType.SECOND_DEGREE,
+            parse_message(0x03, 0, -1, (Motor.SECOND_DEGREE,
                                         None, 95, None))
             in sent_messages)
 

--- a/tests/module/output_module_tests/test_speaker.py
+++ b/tests/module/output_module_tests/test_speaker.py
@@ -28,12 +28,10 @@ class TestSpeaker(unittest.TestCase):
         while self.conn.send_list:
             sent_messages.append(self.conn.send_list.pop())
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Speaker.PropertyType.FREQUENCY,
-                                        None, 95, None))
+            parse_message(0x03, 0, -1, (Speaker.FREQUENCY, None, 95, None))
             in sent_messages)
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Speaker.PropertyType.VOLUME,
-                                        None, 95, None))
+            parse_message(0x03, 0, -1, (Speaker.VOLUME, None, 95, None))
             in sent_messages)
         self.assertTrue(
             parse_message(
@@ -47,12 +45,10 @@ class TestSpeaker(unittest.TestCase):
         while self.conn.send_list:
             sent_messages.append(self.conn.send_list.pop())
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Speaker.PropertyType.FREQUENCY,
-                                        None, 95, None))
+            parse_message(0x03, 0, -1, (Speaker.FREQUENCY, None, 95, None))
             in sent_messages)
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Speaker.PropertyType.VOLUME,
-                                        None, 95, None))
+            parse_message(0x03, 0, -1, (Speaker.VOLUME, None, 95, None))
             in sent_messages)
 
     def test_set_frequency(self):
@@ -64,12 +60,10 @@ class TestSpeaker(unittest.TestCase):
         while self.conn.send_list:
             sent_messages.append(self.conn.send_list.pop())
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Speaker.PropertyType.FREQUENCY,
-                                        None, 95, None))
+            parse_message(0x03, 0, -1, (Speaker.FREQUENCY, None, 95, None))
             in sent_messages)
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Speaker.PropertyType.VOLUME,
-                                        None, 95, None))
+            parse_message(0x03, 0, -1, (Speaker.VOLUME, None, 95, None))
             in sent_messages)
         self.assertTrue(
             parse_message(
@@ -81,8 +75,7 @@ class TestSpeaker(unittest.TestCase):
         _ = self.speaker.frequency
         self.assertEqual(
             self.conn.send_list[0],
-            parse_message(0x03, 0, -1, (Speaker.PropertyType.FREQUENCY,
-                                        None, 95, None)))
+            parse_message(0x03, 0, -1, (Speaker.FREQUENCY, None, 95, None)))
 
     def test_set_volume(self):
         """Test set_volume method."""
@@ -93,12 +86,10 @@ class TestSpeaker(unittest.TestCase):
         while self.conn.send_list:
             sent_messages.append(self.conn.send_list.pop())
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Speaker.PropertyType.FREQUENCY,
-                                        None, 95, None))
+            parse_message(0x03, 0, -1, (Speaker.FREQUENCY, None, 95, None))
             in sent_messages)
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Speaker.PropertyType.VOLUME,
-                                        None, 95, None))
+            parse_message(0x03, 0, -1, (Speaker.VOLUME, None, 95, None))
             in sent_messages)
         self.assertTrue(
             parse_message(
@@ -110,8 +101,7 @@ class TestSpeaker(unittest.TestCase):
         _ = self.speaker.volume
         self.assertEqual(
             self.conn.send_list[0],
-            parse_message(0x03, 0, -1, (Speaker.PropertyType.VOLUME,
-                                        None, 95, None)))
+            parse_message(0x03, 0, -1, (Speaker.VOLUME, None, 95, None)))
 
     def test_set_off(self):
         """Test set_off method"""
@@ -122,12 +112,10 @@ class TestSpeaker(unittest.TestCase):
         while self.conn.send_list:
             sent_messages.append(self.conn.send_list.pop())
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Speaker.PropertyType.FREQUENCY,
-                                        None, 95, None))
+            parse_message(0x03, 0, -1, (Speaker.FREQUENCY, None, 95, None))
             in sent_messages)
         self.assertTrue(
-            parse_message(0x03, 0, -1, (Speaker.PropertyType.VOLUME,
-                                        None, 95, None))
+            parse_message(0x03, 0, -1, (Speaker.VOLUME, None, 95, None))
             in sent_messages)
         self.assertTrue(
             parse_message(


### PR DESCRIPTION
##### - Summary
Remove enum dependency from pymodi

##### - Related Issues

##### - PR Overview
- [ ] This PR closes one of the issues [y/n] (issue #issue_number_here)
- [ ] This PR requires new unit tests [y/n] (please make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (please make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]


