### PR TITLE
Remove stub option from network updater

### DIFF
--- a/modi/firmware_updater.py
+++ b/modi/firmware_updater.py
@@ -700,7 +700,7 @@ class ESP32FirmwareUpdater(serial.Serial):
         self.version = None
         self.__version_to_update = None
 
-    def start_update(self, stub=False, force=False):
+    def start_update(self, force=False):
         self.__boot_to_app()
         self.__version_to_update = self.__get_latest_version()
         self.id = self.__get_esp_id()

--- a/modi/modi.py
+++ b/modi/modi.py
@@ -222,6 +222,6 @@ def reset_module_firmware(target_ids=(0xFFF, )):
     updater.close()
 
 
-def update_network_firmware(stub=True, force=False):
+def update_network_firmware(force=False):
     updater = ESP32FirmwareUpdater()
-    updater.start_update(stub=stub, force=force)
+    updater.start_update(force=force)


### PR DESCRIPTION
##### - Summary
Remove stub option from network updater

##### - Related Issues

##### - PR Overview
- [ ] This PR closes one of the issues [y/n] (issue #issue_number_here)
- [ ] This PR requires new unit tests [y/n] (please make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (please make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]


