### PR TITLE
Add py39 flag in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
     ],


### PR DESCRIPTION
##### - Summary
PyMODI now supports python 3.9
##### - Related Issues

##### - PR Overview
- [ ] This PR closes one of the issues [y/n] (issue #issue_number_here)
- [ ] This PR requires new unit tests [y/n] (please make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (please make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]


